### PR TITLE
Add URL quoting reminder to SKILL.md

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -95,6 +95,8 @@ Organize into subdirectories when it makes sense for the task:
 .firecrawl/news/2024-01/
 ```
 
+**Always quote URLs** - shell interprets `?` and `&` as special characters.
+
 ## Commands
 
 ### Search - Web search with optional scraping


### PR DESCRIPTION
URLs with `?` and `&` need quoting to avoid shell glob/special character interpretation.

Without the reminder, Claude Code sometimes fails on URLs with query params:

```
⏺ Bash(firecrawl scrape https://docs.datadoghq.com/integrations/sql-server/?tab=host -o .firecrawl/datadog-sql-server-integration.md)
  ⎿  Error: Exit code 1
     (eval):1: no matches found: https://docs.datadoghq.com/integrations/sql-server/?tab=host
```

After quoting it works:

```
⏺ Bash(firecrawl scrape "https://docs.datadoghq.com/integrations/sql_server/?tab=host" -o .firecrawl/datadog-sql-server-integration.md)
  ⎿  (No content)
```