### PR TITLE
sync workflows: merge PRs immediately instead of using --auto

### DIFF
--- a/.github/workflows/sync-plugin.yml
+++ b/.github/workflows/sync-plugin.yml
@@ -67,5 +67,8 @@ jobs:
               --base main \
               --head "$BRANCH")
             echo "Created PR: $PR_URL"
-            gh pr merge --repo firecrawl/firecrawl-claude-plugin --auto --merge --delete-branch "$PR_URL"
+            # Merge immediately. --auto requires branch protection with
+            # required checks on the target repo, which firecrawl-claude-plugin
+            # doesn't have, and there's nothing to wait for on a sync PR anyway.
+            gh pr merge --repo firecrawl/firecrawl-claude-plugin --merge --delete-branch "$PR_URL"
           fi

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -62,5 +62,8 @@ jobs:
               --base main \
               --head "$BRANCH")
             echo "Created PR: $PR_URL"
-            gh pr merge --repo firecrawl/firecrawl-cursor-plugin --auto --merge --delete-branch "$PR_URL"
+            # Merge immediately. --auto requires branch protection with
+            # required checks on the target repo, which firecrawl-cursor-plugin
+            # doesn't have, and there's nothing to wait for on a sync PR anyway.
+            gh pr merge --repo firecrawl/firecrawl-cursor-plugin --merge --delete-branch "$PR_URL"
           fi


### PR DESCRIPTION
gh pr merge --auto requires branch protection with required status checks on the target branch. firecrawl-claude-plugin and firecrawl-cursor-plugin don't have that configured, so the workflows fail with "Protected branch rules not configured for this branch (enablePullRequestAutoMerge)" after successfully creating the PR.

There's nothing to wait for on a sync PR anyway, so drop --auto and merge immediately.