### PR TITLE
fix: download screenshot binary when output targets an image file

### DIFF
--- a/src/__tests__/commands/scrape.test.ts
+++ b/src/__tests__/commands/scrape.test.ts
@@ -3,7 +3,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { executeScrape } from '../../commands/scrape';
+import * as fs from 'fs';
+import { executeScrape, handleScrapeCommand } from '../../commands/scrape';
 import { getClient } from '../../utils/client';
 import { initializeConfig } from '../../utils/config';
 import { setupTest, teardownTest } from '../utils/mock-client';
@@ -384,6 +385,69 @@ describe('executeScrape', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Unknown error occurred');
+    });
+  });
+
+  describe('Screenshot binary output', () => {
+    it('should download screenshot binary when output is an image file', async () => {
+      const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+      const mockResponse = {
+        screenshot: 'https://cdn.firecrawl.dev/screenshot-abc.png',
+        metadata: { title: 'Test' },
+      };
+      mockClient.scrape.mockResolvedValue(mockResponse);
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(pngBytes.buffer),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      vi.mock('fs', async () => {
+        const actual = await vi.importActual<typeof import('fs')>('fs');
+        return {
+          ...actual,
+          existsSync: vi.fn().mockReturnValue(true),
+          writeFileSync: vi.fn(),
+          mkdirSync: vi.fn(),
+        };
+      });
+
+      await handleScrapeCommand({
+        url: 'https://example.com',
+        formats: ['screenshot'],
+        output: '/tmp/test-screenshot.png',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://cdn.firecrawl.dev/screenshot-abc.png'
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/tmp/test-screenshot.png',
+        expect.any(Buffer)
+      );
+    });
+
+    it('should not fetch binary when output is not an image extension', async () => {
+      const mockResponse = {
+        screenshot: 'https://cdn.firecrawl.dev/screenshot-abc.png',
+        metadata: { title: 'Test' },
+      };
+      mockClient.scrape.mockResolvedValue(mockResponse);
+
+      const mockFetch = vi.fn();
+      vi.stubGlobal('fetch', mockFetch);
+
+      vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      await handleScrapeCommand({
+        url: 'https://example.com',
+        formats: ['screenshot'],
+        output: '/tmp/result.txt',
+      });
+
+      // Should NOT call fetch — falls through to handleScrapeOutput
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/scrape.ts
+++ b/src/commands/scrape.ts
@@ -183,6 +183,39 @@ export async function handleScrapeCommand(
     effectiveFormats.push('screenshot');
   }
 
+  // When outputting a single screenshot to an image file, fetch the actual
+  // binary instead of writing the URL as text. The multi-URL code path
+  // (handleAllScrapeCommand) already does this, but the single-URL path
+  // was missing it — resulting in a text file containing the CDN URL.
+  if (
+    options.output &&
+    result.success &&
+    result.data?.screenshot &&
+    effectiveFormats.length === 1 &&
+    effectiveFormats[0] === 'screenshot' &&
+    /\.(png|jpg|jpeg|webp)$/i.test(options.output)
+  ) {
+    const fs = await import('fs');
+    const path = await import('path');
+
+    const dir = path.dirname(options.output);
+    if (dir && !fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    const response = await fetch(result.data.screenshot);
+    if (response.ok) {
+      const buffer = Buffer.from(await response.arrayBuffer());
+      fs.writeFileSync(options.output, buffer);
+      return;
+    }
+
+    console.error(
+      `Failed to download screenshot: ${response.status} ${response.statusText}`
+    );
+    process.exit(1);
+  }
+
   handleScrapeOutput(
     result,
     effectiveFormats,


### PR DESCRIPTION
Closes #82

## What

`firecrawl scrape --format screenshot -o output.png` writes the CDN URL as plain text to the file instead of the actual PNG binary. Running `file output.png` shows ASCII text, not image data.

## Why

`handleScrapeCommand` delegates to `handleScrapeOutput`, which calls `formatScreenshotOutput()` for the screenshot format. That function returns the URL as a string, and `writeOutput` writes it with utf-8 encoding. The binary is never fetched.

The multi-URL path (`handleAllScrapeCommand`, around line 598) already handles this correctly — it calls `fetch()` on the screenshot URL, converts to a `Buffer`, and writes the raw bytes. The single-URL path just didn't have this logic.

## Fix

Before falling through to `handleScrapeOutput`, check if we have a single screenshot format going to an image file extension (`.png`, `.jpg`, `.jpeg`, `.webp`). If so, fetch the binary and write it directly. Same pattern the multi-URL path uses.

## Tests

Added two tests:
- Verifies `fetch()` is called and binary buffer is written when output is `.png`
- Verifies `fetch()` is NOT called when output is `.txt` (falls through to existing text behavior)

All 276 tests pass. Type check and formatting clean.