### PR TITLE
Fix: double conversion of pollInterval and timeout in --wait mode

### DIFF
--- a/src/commands/crawl.ts
+++ b/src/commands/crawl.ts
@@ -57,7 +57,7 @@ export async function executeCrawl(
     }
 
     // Build crawl options
-    const crawlOptions: any = {
+    const crawlOptions: Partial<CrawlOptions> & Record<string, any> = {
       integration: 'cli',
     };
 
@@ -97,15 +97,15 @@ export async function executeCrawl(
 
     // If wait mode, use the convenience crawl method with polling
     if (wait) {
-      // Set polling options
+      // Set polling options (SDK expects seconds, not ms)
       if (pollInterval !== undefined) {
-        crawlOptions.pollInterval = pollInterval * 1000; // Convert to milliseconds
+        crawlOptions.pollInterval = pollInterval; // seconds
       } else {
         // Default poll interval: 5 seconds
-        crawlOptions.pollInterval = 5000;
+        crawlOptions.pollInterval = 5;
       }
       if (timeout !== undefined) {
-        crawlOptions.timeout = timeout * 1000; // Convert to milliseconds
+        crawlOptions.timeout = timeout; // seconds
       }
 
       // Show progress if requested - use custom polling for better UX
@@ -117,13 +117,19 @@ export async function executeCrawl(
         process.stderr.write(`Crawling ${urlOrJobId}...\n`);
         process.stderr.write(`Job ID: ${jobId}\n`);
 
-        // Poll for status with progress updates
-        const pollMs = crawlOptions.pollInterval || 5000;
+        // Converts seconds -> ms Only here
+        const pollMs =
+          crawlOptions.pollInterval !== undefined
+            ? crawlOptions.pollInterval * 1000
+            : 5000;
         const startTime = Date.now();
-        const timeoutMs = timeout ? timeout * 1000 : undefined;
+        const timeoutMs =
+          crawlOptions.timeout !== undefined
+            ? crawlOptions.timeout * 1000
+            : undefined;
 
         while (true) {
-          await new Promise((resolve) => setTimeout(resolve, pollMs));
+          await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
 
           const status = await app.getCrawlStatus(jobId);
 


### PR DESCRIPTION
## Fix: Double conversion of pollInterval and timeout in `--wait` mode

### Summary
Fixes an issue where `pollInterval` and `timeout` were incorrectly converted to milliseconds in the CLI before being passed to the SDK, which also performs its own conversion.

This resulted in extremely long polling intervals (e.g., `5s → ~83 minutes`), causing `firecrawl crawl --wait` to appear stuck while still consuming credits server-side.

---

### Root Cause
- CLI converted `pollInterval` and `timeout` from seconds to milliseconds
- SDK also converts them internally (seconds → milliseconds)

Result:
5 → 5000 → 5,000,000 ms (~83 minutes)

---

### Changes
- Pass `pollInterval` and `timeout` as **seconds** to the SDK
- Remove unnecessary `* 1000` conversion in CLI
- Convert to milliseconds **only inside the `--progress` polling loop**
- Improve timeout handling using explicit `undefined` checks

---

### Impact
- Fixes hanging behavior in `firecrawl crawl --wait`
- Prevents silent credit consumption without output
- Keeps `--wait --progress` mode working correctly
- No breaking changes

---

### Verification
```bash
firecrawl crawl https://firecrawl.dev --limit 2 --wait --poll-interval 3