### PR TITLE
feat: add --lockdown flag to scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ firecrawl scrape https://firecrawl.dev https://firecrawl.dev/blog https://docs.f
 | `--include-tags <tags>`    | Only include specific HTML tags                         |
 | `--exclude-tags <tags>`    | Exclude specific HTML tags                              |
 | `--max-age <milliseconds>` | Maximum age of cached content in milliseconds           |
-| `--lockdown-mode`          | Enable lockdown mode for the scrape                     |
+| `--lockdown`               | Enable lockdown mode for the scrape                     |
 | `-o, --output <path>`      | Save output to file                                     |
 | `--json`                   | Output as JSON format                                   |
 | `--pretty`                 | Pretty print JSON output                                |

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ firecrawl scrape https://firecrawl.dev https://firecrawl.dev/blog https://docs.f
 | `--include-tags <tags>`    | Only include specific HTML tags                         |
 | `--exclude-tags <tags>`    | Exclude specific HTML tags                              |
 | `--max-age <milliseconds>` | Maximum age of cached content in milliseconds           |
+| `--lockdown-mode`          | Enable lockdown mode for the scrape                     |
 | `-o, --output <path>`      | Save output to file                                     |
 | `--json`                   | Output as JSON format                                   |
 | `--pretty`                 | Pretty print JSON output                                |

--- a/src/commands/scrape.ts
+++ b/src/commands/scrape.ts
@@ -118,6 +118,10 @@ export async function executeScrape(
     scrapeParams.profile = options.profile;
   }
 
+  if (options.lockdownMode) {
+    scrapeParams.lockdownMode = true;
+  }
+
   // Execute scrape with timing - only wrap the scrape call in try-catch
   const requestStartTime = Date.now();
 

--- a/src/commands/scrape.ts
+++ b/src/commands/scrape.ts
@@ -118,8 +118,8 @@ export async function executeScrape(
     scrapeParams.profile = options.profile;
   }
 
-  if (options.lockdownMode) {
-    scrapeParams.lockdownMode = true;
+  if (options.lockdown) {
+    scrapeParams.lockdown = true;
   }
 
   // Execute scrape with timing - only wrap the scrape call in try-catch

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,7 @@ function createScrapeCommand(): Command {
       '--no-save-changes',
       'Load existing profile data without saving changes (default: saves changes)'
     )
+    .option('--lockdown-mode', 'Enable lockdown mode for the scrape', false)
 
     .action(async (positionalArgs, options) => {
       // Collect URLs from positional args and --url option
@@ -288,6 +289,7 @@ function createDownloadCommand(): Command {
       '--languages <codes>',
       'Comma-separated language codes for scraping (e.g., en,es)'
     )
+    .option('--lockdown-mode', 'Enable lockdown mode for the scrape', false)
     .option('-y, --yes', 'Skip confirmation prompt', false)
     .option(
       '-k, --api-key <key>',

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ function createScrapeCommand(): Command {
       '--no-save-changes',
       'Load existing profile data without saving changes (default: saves changes)'
     )
-    .option('--lockdown-mode', 'Enable lockdown mode for the scrape', false)
+    .option('--lockdown', 'Enable lockdown mode for the scrape', false)
 
     .action(async (positionalArgs, options) => {
       // Collect URLs from positional args and --url option
@@ -289,7 +289,7 @@ function createDownloadCommand(): Command {
       '--languages <codes>',
       'Comma-separated language codes for scraping (e.g., en,es)'
     )
-    .option('--lockdown-mode', 'Enable lockdown mode for the scrape', false)
+    .option('--lockdown', 'Enable lockdown mode for the scrape', false)
     .option('-y, --yes', 'Skip confirmation prompt', false)
     .option(
       '-k, --api-key <key>',

--- a/src/types/scrape.ts
+++ b/src/types/scrape.ts
@@ -62,6 +62,8 @@ export interface ScrapeOptions {
     name: string;
     saveChanges?: boolean;
   };
+  /** Enable lockdown mode for the scrape */
+  lockdownMode?: boolean;
 }
 
 export interface ScrapeResult {

--- a/src/types/scrape.ts
+++ b/src/types/scrape.ts
@@ -63,7 +63,7 @@ export interface ScrapeOptions {
     saveChanges?: boolean;
   };
   /** Enable lockdown mode for the scrape */
-  lockdownMode?: boolean;
+  lockdown?: boolean;
 }
 
 export interface ScrapeResult {

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -121,6 +121,6 @@ export function parseScrapeOptions(options: any): ScrapeOptions {
     location,
     query: options.query,
     profile,
-    lockdownMode: options.lockdownMode,
+    lockdown: options.lockdown,
   };
 }

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -121,5 +121,6 @@ export function parseScrapeOptions(options: any): ScrapeOptions {
     location,
     query: options.query,
     profile,
+    lockdownMode: options.lockdownMode,
   };
 }


### PR DESCRIPTION
Adds `--lockdown` to `scrape` (and `experimental download`). When set, forwards `lockdown: true` to the scrape API.

## Test plan
- [ ] `firecrawl scrape https://example.com --lockdown` sends `lockdown: true` to the API
- [ ] `firecrawl scrape --help` shows the new flag