### PR TITLE
Recognize self-hosted setup in firecrawl --status

### DIFF
--- a/src/__tests__/commands/status.test.ts
+++ b/src/__tests__/commands/status.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for status command self-hosted recognition.
+ *
+ * Regression coverage for #53: a stored apiUrl pointing at a self-hosted
+ * Firecrawl instance with no apiKey must be reported as a configured
+ * "self-hosted" auth source, not "Not authenticated". The fetch helpers
+ * must also avoid sending `Authorization: Bearer undefined` in that case.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getStatus } from '../../commands/status';
+import { initializeConfig, resetConfig } from '../../utils/config';
+import * as credentials from '../../utils/credentials';
+
+vi.mock('../../utils/credentials', () => ({
+  loadCredentials: vi.fn(),
+  saveCredentials: vi.fn(),
+  getConfigDirectoryPath: vi.fn().mockReturnValue('/mock/config/path'),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as any;
+
+describe('getStatus self-hosted handling', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    resetConfig();
+    vi.clearAllMocks();
+    delete process.env.FIRECRAWL_API_KEY;
+    delete process.env.FIRECRAWL_API_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('reports authSource=self-hosted when apiUrl is custom and apiKey is missing', async () => {
+    vi.mocked(credentials.loadCredentials).mockReturnValue({
+      apiUrl: 'http://localhost:3002',
+    });
+    initializeConfig({ apiUrl: 'http://localhost:3002' });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    const status = await getStatus();
+
+    expect(status.authSource).toBe('self-hosted');
+    expect(status.authenticated).toBe(true);
+  });
+
+  it('does not send Authorization header when self-hosted has no apiKey', async () => {
+    vi.mocked(credentials.loadCredentials).mockReturnValue({
+      apiUrl: 'http://localhost:3002',
+    });
+    initializeConfig({ apiUrl: 'http://localhost:3002' });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    await getStatus();
+
+    expect(mockFetch).toHaveBeenCalled();
+    for (const call of mockFetch.mock.calls) {
+      const headers = (call[1]?.headers ?? {}) as Record<string, string>;
+      expect(headers).not.toHaveProperty('Authorization');
+      expect(JSON.stringify(headers)).not.toContain('Bearer undefined');
+    }
+  });
+
+  it('still reports stored when apiKey is present alongside apiUrl', async () => {
+    vi.mocked(credentials.loadCredentials).mockReturnValue({
+      apiKey: 'fc-test-key',
+      apiUrl: 'http://localhost:3002',
+    });
+    initializeConfig({
+      apiKey: 'fc-test-key',
+      apiUrl: 'http://localhost:3002',
+    });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    const status = await getStatus();
+
+    expect(status.authSource).toBe('stored');
+    expect(status.authenticated).toBe(true);
+  });
+
+  it('reports none when no apiKey and apiUrl is the default cloud URL', async () => {
+    vi.mocked(credentials.loadCredentials).mockReturnValue({
+      apiUrl: 'https://api.firecrawl.dev',
+    });
+    initializeConfig({ apiUrl: 'https://api.firecrawl.dev' });
+
+    const status = await getStatus();
+
+    expect(status.authSource).toBe('none');
+    expect(status.authenticated).toBe(false);
+  });
+});

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,11 +7,11 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import packageJson from '../../package.json';
 import { isAuthenticated } from '../utils/auth';
-import { getConfig, validateConfig } from '../utils/config';
+import { getConfig, isCustomApiUrl, validateConfig } from '../utils/config';
 import { loadCredentials } from '../utils/credentials';
 import { isSearchFeedbackDisabledLocally } from './search-feedback';
 
-export type AuthSource = 'env' | 'stored' | 'none';
+export type AuthSource = 'env' | 'stored' | 'self-hosted' | 'none';
 
 interface QueueStatusResponse {
   success: boolean;
@@ -55,7 +55,11 @@ interface LocalStatus {
 }
 
 /**
- * Detect how the user is authenticated
+ * Detect how the user is authenticated.
+ *
+ * `self-hosted` is reported when the stored credentials point at a custom
+ * apiUrl and no apiKey is present. Self-hosted Firecrawl instances do not
+ * require an API key, so the CLI is considered configured in that state.
  */
 export function getAuthSource(): AuthSource {
   if (process.env.FIRECRAWL_API_KEY) {
@@ -65,23 +69,38 @@ export function getAuthSource(): AuthSource {
   if (stored?.apiKey) {
     return 'stored';
   }
+  if (stored?.apiUrl && isCustomApiUrl(stored.apiUrl)) {
+    return 'self-hosted';
+  }
   return 'none';
+}
+
+/**
+ * Build request headers for a status API call. Omits Authorization entirely
+ * when no apiKey is present (self-hosted with no key) so the server does not
+ * see `Authorization: Bearer undefined`.
+ */
+function buildStatusHeaders(apiKey?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
 }
 
 /**
  * Fetch queue status from API
  */
 async function fetchQueueStatus(
-  apiKey: string,
+  apiKey: string | undefined,
   apiUrl: string
 ): Promise<QueueStatusResponse> {
   const url = `${apiUrl.replace(/\/$/, '')}/v2/team/queue-status`;
   const response = await fetch(url, {
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
+    headers: buildStatusHeaders(apiKey),
   });
 
   if (!response.ok) {
@@ -98,16 +117,13 @@ async function fetchQueueStatus(
  * Fetch credit usage from API
  */
 async function fetchCreditUsage(
-  apiKey: string,
+  apiKey: string | undefined,
   apiUrl: string
 ): Promise<CreditUsageResponse> {
   const url = `${apiUrl.replace(/\/$/, '')}/v2/team/credit-usage`;
   const response = await fetch(url, {
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
+    headers: buildStatusHeaders(apiKey),
   });
 
   if (!response.ok) {
@@ -125,9 +141,13 @@ async function fetchCreditUsage(
  */
 export async function getStatus(): Promise<StatusResult> {
   const authSource = getAuthSource();
+  // Self-hosted setups (custom apiUrl, no apiKey) are a valid configured state.
+  // Treat them as authenticated for reporting purposes so we don't tell users
+  // to run `firecrawl login` against an instance that has no login flow.
+  const authenticated = isAuthenticated() || authSource === 'self-hosted';
   const result: StatusResult = {
     version: packageJson.version,
-    authenticated: isAuthenticated(),
+    authenticated,
     authSource,
   };
 
@@ -142,10 +162,11 @@ export async function getStatus(): Promise<StatusResult> {
 
     const apiUrl = config.apiUrl || 'https://api.firecrawl.dev';
 
-    // Fetch both endpoints in parallel
+    // Fetch both endpoints in parallel. apiKey may be undefined for
+    // self-hosted instances; the fetch helpers omit Authorization in that case.
     const [queueStatus, creditUsage] = await Promise.all([
-      fetchQueueStatus(apiKey!, apiUrl),
-      fetchCreditUsage(apiKey!, apiUrl),
+      fetchQueueStatus(apiKey, apiUrl),
+      fetchCreditUsage(apiKey, apiUrl),
     ]);
 
     if (queueStatus.success && queueStatus.maxConcurrency !== undefined) {
@@ -262,13 +283,20 @@ export async function handleStatusCommand(): Promise<void> {
 
   // Auth status with source
   if (status.authenticated) {
-    const sourceLabel =
-      status.authSource === 'env'
-        ? 'via FIRECRAWL_API_KEY'
-        : 'via stored credentials';
-    console.log(
-      `  ${green}●${reset} Authenticated ${dim}${sourceLabel}${reset}`
-    );
+    if (status.authSource === 'self-hosted') {
+      const apiUrl = getConfig().apiUrl;
+      console.log(
+        `  ${green}●${reset} Self-hosted ${dim}${apiUrl || ''}${reset}`
+      );
+    } else {
+      const sourceLabel =
+        status.authSource === 'env'
+          ? 'via FIRECRAWL_API_KEY'
+          : 'via stored credentials';
+      console.log(
+        `  ${green}●${reset} Authenticated ${dim}${sourceLabel}${reset}`
+      );
+    }
   } else {
     console.log(`  ${red}●${reset} Not authenticated`);
     console.log(`  ${dim}Run 'firecrawl login' to authenticate${reset}`);


### PR DESCRIPTION
## Problem

`firecrawl --status` was reporting `Not authenticated` and pointing users at `firecrawl login` whenever the stored credentials only had `apiUrl` set (e.g. a self-hosted instance). Self-hosted Firecrawl does not require an API key, so this state is a valid configured setup, not a missing-credentials state.

The same code path also produced `Authorization: Bearer undefined` in outbound requests when `apiKey` was missing, since the header was unconditionally formatted from a possibly-undefined value.

Tracked as #53.

## Repro on `main`

```bash
# Fresh setup, no credentials.json yet
firecrawl config --api-url http://localhost:3002
# credentials.json now contains: { "apiUrl": "http://localhost:3002" }

firecrawl --status
# Reports: Not authenticated. Run 'firecrawl login' to authenticate.
```

## Fix

- Add `self-hosted` as a new `AuthSource` in `src/commands/status.ts`.
- `getAuthSource()` returns `self-hosted` when stored credentials have a custom `apiUrl` and no `apiKey`.
- `getStatus()` treats `self-hosted` as authenticated for reporting purposes, so the status flow keeps going and queries the queue-status / credit-usage endpoints (which the issue notes already succeed against self-hosted instances).
- `fetchQueueStatus` / `fetchCreditUsage` now build headers via a small `buildStatusHeaders()` helper that omits `Authorization` entirely when there is no `apiKey`. This removes the `Bearer undefined` header.
- `handleStatusCommand()` prints `Self-hosted <apiUrl>` in green instead of the `Not authenticated` line for this state.

The cloud paths (`env`, `stored`) are unchanged.

## Tests

New `src/__tests__/commands/status.test.ts` with four cases:

- `apiUrl` custom + no `apiKey` reports `authSource=self-hosted` and `authenticated=true`.
- `Authorization` header is omitted entirely when self-hosted has no `apiKey`; the literal string `Bearer undefined` does not appear in any outgoing request.
- `apiKey` + custom `apiUrl` still reports `stored` (no regression on existing cloud-with-custom-URL flow).
- No `apiKey` + default cloud URL still reports `none` and `authenticated=false`.

Verified locally:

- `npx vitest run` → 279 passed (16 files).
- `npx tsc --noEmit` → clean.
- `npx prettier --check` → clean.

The two new self-hosted tests fail on `main` (the bug), pass with the fix.