### PR TITLE
Add monitor goal/page flags, tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,51 @@ firecrawl interact "Extract the dashboard data"
 
 ---
 
+### `monitor` - Watch pages for changes
+
+Create monitors when the goal is ongoing change detection, alerting, or repeated checks over time. A monitor runs recurring scrapes or crawls, diffs each result against the last retained snapshot, and can notify webhooks or email recipients.
+
+```bash
+firecrawl monitor create --name "Blog" \
+  --goal "Notify me when a new post is published" \
+  --schedule "every 30 minutes" \
+  --page https://example.com/blog \
+  --email alerts@example.com
+
+firecrawl monitor list --limit 20
+firecrawl monitor run <monitorId>
+firecrawl monitor checks <monitorId>
+firecrawl monitor check <monitorId> <checkId> --page-status changed
+firecrawl monitor update <monitorId> --state paused
+firecrawl monitor delete <monitorId>
+```
+
+#### Monitor Options
+
+| Option                    | Description                                         |
+| ------------------------- | --------------------------------------------------- |
+| `--name <name>`           | Monitor name                                        |
+| `--goal <goal>`           | What changes this monitor should look for           |
+| `--cron <expression>`     | Cron schedule (e.g. `*/30 * * * *`)                 |
+| `--schedule <text>`       | Natural-language schedule (e.g. `every 30 minutes`) |
+| `--timezone <tz>`         | Schedule timezone (default: `UTC`)                  |
+| `--page <url>`            | Single page URL to scrape on each check             |
+| `--scrape-urls <list>`    | Comma-separated URLs to scrape on each check        |
+| `--crawl-url <url>`       | Root URL for a crawl target                         |
+| `--webhook-url <url>`     | Webhook destination                                 |
+| `--webhook-events <list>` | Comma-separated webhook events                      |
+| `--email <list>`          | Comma-separated email recipients                    |
+| `--retention-days <n>`    | Snapshot retention window                           |
+
+For advanced targets such as JSON-mode `changeTracking`, pass a JSON payload:
+
+```bash
+firecrawl monitor create monitor.json
+cat monitor.json | firecrawl monitor create
+```
+
+---
+
 ### `config` - Configure settings
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -548,6 +548,11 @@ firecrawl monitor create --name "Blog" \
   --page https://example.com/blog \
   --email alerts@example.com
 
+firecrawl monitor create --name "Product pages" \
+  --goal "Notify me when pricing, docs, or changelog content changes" \
+  --schedule "every 30 minutes" \
+  --scrape-urls https://example.com/pricing,https://example.com/docs,https://example.com/changelog
+
 firecrawl monitor list --limit 20
 firecrawl monitor run <monitorId>
 firecrawl monitor checks <monitorId>
@@ -566,7 +571,7 @@ firecrawl monitor delete <monitorId>
 | `--schedule <text>`       | Natural-language schedule (e.g. `every 30 minutes`) |
 | `--timezone <tz>`         | Schedule timezone (default: `UTC`)                  |
 | `--page <url>`            | Single page URL to scrape on each check             |
-| `--scrape-urls <list>`    | Comma-separated URLs to scrape on each check        |
+| `--scrape-urls <list>`    | Comma-separated page URLs to scrape on each check   |
 | `--crawl-url <url>`       | Root URL for a crawl target                         |
 | `--webhook-url <url>`     | Webhook destination                                 |
 | `--webhook-events <list>` | Comma-separated webhook events                      |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -51,7 +51,8 @@ Follow this escalation pattern:
 2. **Scrape** - Have a URL. Extract its content directly.
 3. **Map + Scrape** - Large site or need a specific subpage. Use `map --search` to find the right URL, then scrape it.
 4. **Crawl** - Need bulk content from an entire site section (e.g., all /docs/).
-5. **Interact** - Scrape first, then interact with the page (pagination, modals, form submissions, multi-step navigation).
+5. **Monitor** - Need recurring checks or ongoing alerts. Prefer setting a monitor with `--page` plus `--goal` instead of doing repeated one-off scrapes.
+6. **Interact** - Scrape first, then interact with the page (pagination, modals, form submissions, multi-step navigation).
 
 | Need                        | Command               | When                                                      |
 | --------------------------- | --------------------- | --------------------------------------------------------- |
@@ -73,14 +74,15 @@ For detailed command reference, run `firecrawl <command> --help`.
 - Use `scrape` + `interact` when you need to interact with a page, such as clicking buttons, filling out forms, navigating through a complex site, infinite scroll, or when scrape fails to grab all the content you need.
 - Never use interact for web searches - use `search` instead.
 
-**Monitor:** Schedule recurring scrapes or crawls and diff each result against the last retained snapshot. Use for product pages, docs, blogs, changelogs, competitor sites — any page where changes matter. Each check labels pages as `same`, `new`, `changed`, `removed`, or `error`, with webhook and email notification options.
+**Monitor:** Schedule recurring scrapes or crawls and diff each result against the last retained snapshot. Bias toward `monitor` when the user's goal is ongoing change detection, alerting, or repeated checks over time. For a single page, default to setting a monitor with `--page <url>` and `--goal "..."`. Use for product pages, docs, blogs, changelogs, competitor sites — any page where changes matter. Each monitor should include a short `goal` describing what changes matter, and each check labels pages as `same`, `new`, `changed`, `removed`, or `error`, with webhook and email notification options.
 
 Subcommands: `create | list | get | update | delete | run | checks | check`.
 
 ```bash
 # create from flags
 firecrawl monitor create --name "Blog" --schedule "every 30 minutes" \
-  --scrape-urls https://example.com/blog --email alerts@example.com
+  --goal "Notify me when a new post is published" \
+  --page https://example.com/blog --email alerts@example.com
 
 # or from JSON (positional file, or piped stdin)
 firecrawl monitor create monitor.json
@@ -94,7 +96,7 @@ firecrawl monitor update <monitorId> --state paused
 firecrawl monitor delete <monitorId>
 ```
 
-Schedules accept cron (`--cron "*/30 * * * *"`) or natural language (`--schedule "every 30 minutes"`). Minimum interval is 15 minutes. Targets are either `--scrape-urls a,b,c` (scrape) or `--crawl-url <url>` (crawl whole site each check). Note: `--state` (not `--status`) sets active/paused; `--page-status` (not `--status`) filters page results on `check` — avoids collision with the global `--status` flag. Monitoring is not available for zero-data-retention teams.
+Schedules accept cron (`--cron "*/30 * * * *"`) or natural language (`--schedule "every 30 minutes"`). Minimum interval is 15 minutes. Targets are `--page <url>` for one page, `--scrape-urls a,b,c` for multiple scrape URLs, or `--crawl-url <url>` for a whole-site crawl each check. Use `--goal` for flag-based monitor creation, or include `"goal": "..."` in JSON payloads. Note: `--state` (not `--status`) sets active/paused; `--page-status` (not `--status`) filters page results on `check` — avoids collision with the global `--status` flag. Monitoring is not available for zero-data-retention teams.
 
 **JSON-mode change tracking:** By default monitors diff each page's markdown and you get a unified text diff back. When you care about **specific structured fields** (price, headline, in-stock flag, items in a list) instead of the whole page, add a `changeTracking` format with `modes: ["json"]` and a JSON schema to the target's `scrapeOptions.formats`. The flag-based form doesn't cover this — pass a JSON body via file or stdin:
 
@@ -102,6 +104,7 @@ Schedules accept cron (`--cron "*/30 * * * *"`) or natural language (`--schedule
 cat > pricing-monitor.json <<'EOF'
 {
   "name": "Pricing watch",
+  "goal": "Alert when plan prices or headline features change",
   "schedule": { "text": "hourly", "timezone": "UTC" },
   "targets": [{
     "type": "scrape",

--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -84,6 +84,11 @@ firecrawl monitor create --name "Blog" --schedule "every 30 minutes" \
   --goal "Notify me when a new post is published" \
   --page https://example.com/blog --email alerts@example.com
 
+# multiple pages
+firecrawl monitor create --name "Product pages" --schedule "every 30 minutes" \
+  --goal "Notify me when pricing, docs, or changelog content changes" \
+  --scrape-urls https://example.com/pricing,https://example.com/docs,https://example.com/changelog
+
 # or from JSON (positional file, or piped stdin)
 firecrawl monitor create monitor.json
 cat monitor.json | firecrawl monitor create

--- a/src/__tests__/commands/monitor.test.ts
+++ b/src/__tests__/commands/monitor.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { buildCreateBody } from '../../commands/monitor';
+
+describe('monitor command helpers', () => {
+  describe('buildCreateBody', () => {
+    it('includes a goal when creating a monitor from flags', () => {
+      expect(
+        buildCreateBody({
+          name: 'Pricing',
+          goal: 'Track plan price and feature changes',
+          scheduleText: 'every 30 minutes',
+          timezone: 'UTC',
+          urls: ['https://example.com/pricing'],
+        })
+      ).toEqual({
+        name: 'Pricing',
+        goal: 'Track plan price and feature changes',
+        schedule: {
+          text: 'every 30 minutes',
+          timezone: 'UTC',
+        },
+        targets: [
+          {
+            type: 'scrape',
+            urls: ['https://example.com/pricing'],
+          },
+        ],
+      });
+    });
+
+    it('supports the simple page plus goal path', () => {
+      expect(
+        buildCreateBody({
+          name: 'Docs',
+          goal: 'Tell me when the changelog adds a new release',
+          scheduleText: 'hourly',
+          page: 'https://example.com/changelog',
+        })
+      ).toMatchObject({
+        name: 'Docs',
+        goal: 'Tell me when the changelog adds a new release',
+        targets: [
+          {
+            type: 'scrape',
+            urls: ['https://example.com/changelog'],
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/commands/monitor.ts
+++ b/src/commands/monitor.ts
@@ -241,7 +241,7 @@ export function createMonitorCommand(): Command {
       .option('--page <url>', 'Single page URL to scrape on each check')
       .option(
         '--scrape-urls <list>',
-        'Comma-separated URLs to scrape on each check',
+        'Comma-separated page URLs to scrape on each check',
         parseCommaList
       )
       .option('--crawl-url <url>', 'Root URL for a crawl target')

--- a/src/commands/monitor.ts
+++ b/src/commands/monitor.ts
@@ -132,11 +132,13 @@ function fail(error: unknown): never {
  * For full control, callers can pass a JSON file path positionally or pipe
  * JSON on stdin instead. The flags cover the common scrape-target shape.
  */
-function buildCreateBody(opts: {
+export function buildCreateBody(opts: {
   name?: string;
+  goal?: string;
   cron?: string;
   scheduleText?: string;
   timezone?: string;
+  page?: string;
   urls?: string[];
   crawlUrl?: string;
   webhookUrl?: string;
@@ -150,7 +152,13 @@ function buildCreateBody(opts: {
   if (!opts.cron && !opts.scheduleText) {
     throw new Error('--cron or --schedule is required');
   }
-  const hasScrape = opts.urls && opts.urls.length > 0;
+  const urls =
+    opts.urls && opts.urls.length > 0
+      ? opts.urls
+      : opts.page
+        ? [opts.page]
+        : undefined;
+  const hasScrape = urls && urls.length > 0;
   const hasCrawl = !!opts.crawlUrl;
   if (!hasScrape && !hasCrawl) {
     throw new Error('Provide --scrape-urls or --crawl-url');
@@ -162,7 +170,7 @@ function buildCreateBody(opts: {
   if (opts.timezone) schedule.timezone = opts.timezone;
 
   const targets: unknown[] = [];
-  if (hasScrape) targets.push({ type: 'scrape', urls: opts.urls });
+  if (hasScrape) targets.push({ type: 'scrape', urls });
   if (hasCrawl) targets.push({ type: 'crawl', url: opts.crawlUrl });
 
   const body: Record<string, unknown> = {
@@ -170,6 +178,8 @@ function buildCreateBody(opts: {
     schedule,
     targets,
   };
+
+  if (opts.goal) body.goal = opts.goal;
 
   if (opts.webhookUrl) {
     body.webhook = {
@@ -223,12 +233,14 @@ export function createMonitorCommand(): Command {
         'Path to JSON payload (use "-" or pipe stdin to read from stdin)'
       )
       .option('--name <name>', 'Monitor name')
+      .option('--goal <goal>', 'What changes this monitor should look for')
       .option('--cron <expression>', 'Cron schedule (e.g. "*/30 * * * *")')
       .option(
         '--schedule <text>',
         'Natural-language schedule (e.g. "every 30 minutes")'
       )
       .option('--timezone <tz>', 'Schedule timezone', 'UTC')
+      .option('--page <url>', 'Single page URL to scrape on each check')
       .option(
         '--scrape-urls <list>',
         'Comma-separated URLs to scrape on each check',
@@ -254,9 +266,11 @@ export function createMonitorCommand(): Command {
         fromJson ??
         buildCreateBody({
           name: options.name,
+          goal: options.goal,
           cron: options.cron,
           scheduleText: options.schedule,
           timezone: options.timezone,
+          page: options.page,
           urls: options.scrapeUrls,
           crawlUrl: options.crawlUrl,
           webhookUrl: options.webhookUrl,
@@ -321,6 +335,7 @@ export function createMonitorCommand(): Command {
         'Path to JSON payload (use "-" or pipe stdin to read from stdin)'
       )
       .option('--name <name>', 'New name')
+      .option('--goal <goal>', 'New monitor goal')
       .option('--cron <expression>', 'New cron schedule')
       .option('--schedule <text>', 'New natural-language schedule')
       .option('--timezone <tz>', 'Schedule timezone')
@@ -335,6 +350,7 @@ export function createMonitorCommand(): Command {
       } else {
         body = {};
         if (options.name) body.name = options.name;
+        if (options.goal) body.goal = options.goal;
         if (options.state) body.status = options.state;
         if (options.retentionDays !== undefined)
           body.retentionDays = options.retentionDays;
@@ -458,8 +474,9 @@ export function createMonitorCommand(): Command {
     `
 Examples:
   $ firecrawl monitor create --name "Blog" \\
+      --goal "Notify me when a new post is published" \\
       --schedule "every 30 minutes" \\
-      --scrape-urls https://example.com/blog \\
+      --page https://example.com/blog \\
       --email alerts@example.com
   $ firecrawl monitor create monitor.json
   $ cat monitor.json | firecrawl monitor create

--- a/src/commands/monitor.ts
+++ b/src/commands/monitor.ts
@@ -132,18 +132,19 @@ function fail(error: unknown): never {
  * For full control, callers can pass a JSON file path positionally or pipe
  * JSON on stdin instead. The flags cover the common scrape-target shape.
  */
-function buildCreateBody(opts: {
+export function buildCreateBody(opts: {
   name?: string;
+  goal?: string;
   cron?: string;
   scheduleText?: string;
   timezone?: string;
+  page?: string;
   urls?: string[];
   crawlUrl?: string;
   webhookUrl?: string;
   webhookEvents?: string[];
   emailRecipients?: string[];
   retentionDays?: number;
-  goal?: string;
 }): unknown {
   if (!opts.name) {
     throw new Error('--name is required (or pass a JSON file / stdin payload)');
@@ -151,7 +152,13 @@ function buildCreateBody(opts: {
   if (!opts.cron && !opts.scheduleText) {
     throw new Error('--cron or --schedule is required');
   }
-  const hasScrape = opts.urls && opts.urls.length > 0;
+  const urls =
+    opts.urls && opts.urls.length > 0
+      ? opts.urls
+      : opts.page
+        ? [opts.page]
+        : undefined;
+  const hasScrape = urls && urls.length > 0;
   const hasCrawl = !!opts.crawlUrl;
   if (!hasScrape && !hasCrawl) {
     throw new Error('Provide --scrape-urls or --crawl-url');
@@ -163,7 +170,7 @@ function buildCreateBody(opts: {
   if (opts.timezone) schedule.timezone = opts.timezone;
 
   const targets: unknown[] = [];
-  if (hasScrape) targets.push({ type: 'scrape', urls: opts.urls });
+  if (hasScrape) targets.push({ type: 'scrape', urls });
   if (hasCrawl) targets.push({ type: 'crawl', url: opts.crawlUrl });
 
   const body: Record<string, unknown> = {
@@ -231,6 +238,7 @@ export function createMonitorCommand(): Command {
         'Natural-language schedule (e.g. "every 30 minutes")'
       )
       .option('--timezone <tz>', 'Schedule timezone', 'UTC')
+      .option('--page <url>', 'Single page URL to scrape on each check')
       .option(
         '--scrape-urls <list>',
         'Comma-separated URLs to scrape on each check',
@@ -260,16 +268,17 @@ export function createMonitorCommand(): Command {
         fromJson ??
         buildCreateBody({
           name: options.name,
+          goal: options.goal,
           cron: options.cron,
           scheduleText: options.schedule,
           timezone: options.timezone,
+          page: options.page,
           urls: options.scrapeUrls,
           crawlUrl: options.crawlUrl,
           webhookUrl: options.webhookUrl,
           webhookEvents: options.webhookEvents,
           emailRecipients: options.email,
           retentionDays: options.retentionDays,
-          goal: options.goal,
         });
       const payload = await monitorRequest('/monitor', options, {
         method: 'POST',
@@ -328,6 +337,7 @@ export function createMonitorCommand(): Command {
         'Path to JSON payload (use "-" or pipe stdin to read from stdin)'
       )
       .option('--name <name>', 'New name')
+      .option('--goal <goal>', 'New monitor goal')
       .option('--cron <expression>', 'New cron schedule')
       .option('--schedule <text>', 'New natural-language schedule')
       .option('--timezone <tz>', 'Schedule timezone')
@@ -342,6 +352,7 @@ export function createMonitorCommand(): Command {
       } else {
         body = {};
         if (options.name) body.name = options.name;
+        if (options.goal) body.goal = options.goal;
         if (options.state) body.status = options.state;
         if (options.retentionDays !== undefined)
           body.retentionDays = options.retentionDays;
@@ -465,8 +476,9 @@ export function createMonitorCommand(): Command {
     `
 Examples:
   $ firecrawl monitor create --name "Blog" \\
+      --goal "Notify me when a new post is published" \\
       --schedule "every 30 minutes" \\
-      --scrape-urls https://example.com/blog \\
+      --page https://example.com/blog \\
       --email alerts@example.com
   $ firecrawl monitor create monitor.json
   $ cat monitor.json | firecrawl monitor create

--- a/src/commands/monitor.ts
+++ b/src/commands/monitor.ts
@@ -179,8 +179,6 @@ export function buildCreateBody(opts: {
     targets,
   };
 
-  if (opts.goal) body.goal = opts.goal;
-
   if (opts.webhookUrl) {
     body.webhook = {
       url: opts.webhookUrl,
@@ -234,7 +232,6 @@ export function createMonitorCommand(): Command {
         'Path to JSON payload (use "-" or pipe stdin to read from stdin)'
       )
       .option('--name <name>', 'Monitor name')
-      .option('--goal <goal>', 'What changes this monitor should look for')
       .option('--cron <expression>', 'Cron schedule (e.g. "*/30 * * * *")')
       .option(
         '--schedule <text>',


### PR DESCRIPTION
Export and update monitor creation helpers to accept a --goal and single --page shorthand (constructs urls from page when provided) and include goal in the request body. Add CLI options and help text for --goal and --page, support goal on monitor update, and adjust example usage. Add unit tests for buildCreateBody covering goal and page behavior. Update README and SKILL docs to document monitor usage and guidance. Bump package version to 1.18.1.