### PR TITLE
Refactor package dependencies to replace '@mendable/firecrawl-js' wit…

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.2.1",
-    "@mendable/firecrawl-js": "4.24.0",
+    "firecrawl": "4.24.0",
     "commander": "^14.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       '@inquirer/prompts':
         specifier: ^8.2.1
         version: 8.2.1(@types/node@20.19.27)
-      '@mendable/firecrawl-js':
-        specifier: 4.24.0
-        version: 4.24.0
       commander:
         specifier: ^14.0.2
         version: 14.0.2
+      firecrawl:
+        specifier: 4.24.0
+        version: 4.24.0
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -331,10 +331,6 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@mendable/firecrawl-js@4.24.0':
-    resolution: {integrity: sha512-VergmApaVrr4zdAVchmJJajQn+o6+m6UjqNnf3E6RlNfISXLDIHrrvfYQSoe1cFGb+gWfHzPTJSXa13jWC7THg==}
-    engines: {node: '>=22.0.0'}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
@@ -661,8 +657,8 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  firecrawl@4.16.0:
-    resolution: {integrity: sha512-7SJ/FWhZBtW2gTCE/BsvU+gbfIpfTq+D9IH82l9MacauLVptaY6EdYAhrK3YSMC9yr5NxvxRcpZKcXG/nqjiiQ==}
+  firecrawl@4.24.0:
+    resolution: {integrity: sha512-kP9E3Up7eF/0Qe8x2tPU/Mcvx0v6Vks397Gkln1+gZKyLAGtIQNEW0+KZcDPS/meRPodGlVi4Z77doQ2Twq74w==}
     engines: {node: '>=22.0.0'}
 
   follow-redirects@1.15.11:
@@ -1260,16 +1256,6 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@mendable/firecrawl-js@4.24.0':
-    dependencies:
-      axios: 1.15.2
-      firecrawl: 4.16.0
-      typescript-event-target: 1.1.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - debug
-
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
 
@@ -1561,7 +1547,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  firecrawl@4.16.0:
+  firecrawl@4.24.0:
     dependencies:
       axios: 1.15.2
       typescript-event-target: 1.1.2

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -8,7 +8,7 @@ import type {
   AgentStatus,
   AgentStatusResult,
 } from '../types/agent';
-import type { AgentWebhookConfig } from '@mendable/firecrawl-js';
+import type { AgentWebhookConfig } from 'firecrawl';
 import { getClient } from '../utils/client';
 import { isJobId } from '../utils/job';
 import { writeOutput } from '../utils/output';

--- a/src/commands/monitor.ts
+++ b/src/commands/monitor.ts
@@ -4,7 +4,7 @@
  * Monitors run recurring scrapes/crawls and diff each result against the last
  * retained snapshot. See features/monitoring in the docs.
  *
- * @mendable/firecrawl-js@4.22.2 exposes monitor methods (createMonitor,
+ * firecrawl@4.22.2 exposes monitor methods (createMonitor,
  * listMonitors, getMonitor, updateMonitor, deleteMonitor, runMonitor,
  * listMonitorChecks, getMonitorCheck), but its HttpClient injects a top-level
  * `origin: js-sdk@<version>` field into every POST/PATCH body and the

--- a/src/commands/parse.ts
+++ b/src/commands/parse.ts
@@ -8,7 +8,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { FormatOption } from '@mendable/firecrawl-js';
+import type { FormatOption } from 'firecrawl';
 import type { ParseOptions, ParseResult } from '../types/parse';
 import type { ScrapeFormat } from '../types/scrape';
 import { getClient } from '../utils/client';

--- a/src/commands/scrape.ts
+++ b/src/commands/scrape.ts
@@ -2,7 +2,7 @@
  * Scrape command implementation
  */
 
-import type { FormatOption } from '@mendable/firecrawl-js';
+import type { FormatOption } from 'firecrawl';
 import type {
   ScrapeOptions,
   ScrapeResult,

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -2,7 +2,7 @@
  * Search command implementation
  */
 
-import type { FormatOption } from '@mendable/firecrawl-js';
+import type { FormatOption } from 'firecrawl';
 import type {
   SearchOptions,
   SearchResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ import { ensureAuthenticated, printBanner } from './utils/auth';
 import packageJson from '../package.json';
 import type { SearchSource, SearchCategory } from './types/search';
 import type { ScrapeFormat } from './types/scrape';
-import type { AgentWebhookConfig } from '@mendable/firecrawl-js';
+import type { AgentWebhookConfig } from 'firecrawl';
 import { createCreateCommand } from './commands/create';
 
 // Initialize global configuration from environment variables

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -2,7 +2,7 @@
  * Types and interfaces for the agent command
  */
 
-import type { AgentWebhookConfig } from '@mendable/firecrawl-js';
+import type { AgentWebhookConfig } from 'firecrawl';
 
 export type AgentModel = 'spark-1-pro' | 'spark-1-mini';
 

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -3,8 +3,8 @@
  * Provides a singleton client instance initialized with global configuration
  */
 
-import Firecrawl from '@mendable/firecrawl-js';
-import type { FirecrawlClientOptions } from '@mendable/firecrawl-js';
+import Firecrawl from 'firecrawl';
+import type { FirecrawlClientOptions } from 'firecrawl';
 import {
   getConfig,
   validateConfig,

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -3,7 +3,7 @@
  * Provides a singleton client instance initialized with global configuration
  */
 
-import Firecrawl from 'firecrawl';
+import { Firecrawl } from 'firecrawl';
 import type { FirecrawlClientOptions } from 'firecrawl';
 import {
   getConfig,


### PR DESCRIPTION
…h 'firecrawl' in package.json and update related imports across the codebase. This change ensures consistency and aligns with the new package naming convention.