### PR TITLE
docs(skills): warn before scraped search

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -40,6 +40,10 @@ firecrawl scrape "https://firecrawl.dev" -o .firecrawl/install-check.md
 ```
 
 ```bash
+# Basic search first; inspect URLs/snippets before deciding what to scrape.
+firecrawl search "query" --limit 5
+
+# Advanced: scrape each result inline. Adds scrape credits per result; keep limits small.
 firecrawl search "query" --scrape --limit 3
 ```
 
@@ -203,6 +207,7 @@ Use `modes: ["json", "git-diff"]` for **mixed mode**: you get both `diff.json` (
 
 **Avoid redundant fetches:**
 
+- Start with plain `search`; use `search --scrape` only when you need full content for every result. `--scrape` adds scrape credits per result, so keep `--limit` small.
 - `search --scrape` already fetches full page content. Don't re-scrape those URLs.
 - Check `.firecrawl/` for existing data before fetching again.
 

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -23,11 +23,12 @@ Web search with optional content scraping. Returns search results as JSON, optio
 # Basic search
 firecrawl search "your query" -o .firecrawl/result.json --json
 
-# Search and scrape full page content from results
-firecrawl search "your query" --scrape -o .firecrawl/scraped.json --json
-
 # News from the past day
 firecrawl search "your query" --sources news --tbs qdr:d -o .firecrawl/news.json --json
+
+# Advanced: search and scrape full page content for each result
+# Use only when snippets/URLs are not enough; this adds scrape credits per result.
+firecrawl search "your query" --scrape --limit 3 -o .firecrawl/scraped.json --json
 ```
 
 ## Options
@@ -47,7 +48,9 @@ firecrawl search "your query" --sources news --tbs qdr:d -o .firecrawl/news.json
 
 ## Tips
 
-- **`--scrape` fetches full content** — don't re-scrape URLs from search results. This saves credits and avoids redundant fetches.
+- **Start without `--scrape` by default.** Plain search costs the least and usually gives enough URLs/snippets to choose what to inspect next.
+- **Use `--scrape` only when you need full page content for every returned result.** It adds normal scrape credits for each result page on top of the search cost, so keep `--limit` small.
+- **If you already used `--scrape`, do not re-scrape those URLs.** The full content is already in the search output.
 - Always write results to `.firecrawl/` with `-o` to avoid context window bloat.
 - Use `jq` to extract URLs or titles: `jq -r '.data.web[].url' .firecrawl/search.json`
 - Naming convention: `.firecrawl/search-{query}.json` or `.firecrawl/search-{query}-scraped.json`


### PR DESCRIPTION
## Summary
- make plain `firecrawl search` the default example in the search skills
- move `--scrape` to an advanced/full-content example with a small limit
- add an explicit warning that `--scrape` adds scrape credits per result

## Why
The AX credit research found agents copying the skill quick start into `firecrawl search --scrape --limit 6`, turning low-cost searches into hundreds of credits because each result page is scraped inline. This keeps the useful full-content mode documented, but stops presenting it as the default path.

## Validation
- `git diff --check`
- pre-commit lint-staged ran `prettier --write` on the edited markdown files

Evidence refs from local lab: F101 / E160 / E161.