### PR TITLE
feat(scrape): add redact-pii flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ firecrawl scrape https://firecrawl.dev https://firecrawl.dev/blog https://docs.f
 | `--exclude-tags <tags>`    | Exclude specific HTML tags                              |
 | `--max-age <milliseconds>` | Maximum age of cached content in milliseconds           |
 | `--lockdown`               | Enable lockdown mode for the scrape                     |
+| `--redact-pii`             | Redact personally identifiable information from output  |
 | `--schema <json>`          | JSON schema for structured extraction                   |
 | `--schema-file <path>`     | Path to JSON schema file for structured extraction      |
 | `--actions <json>`         | JSON actions array to run during scrape                 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -50,6 +50,7 @@ firecrawl scrape "https://example.com/pricing" --query "What is the enterprise p
 | `--wait-for <ms>`        | Wait for JS rendering before scraping                            |
 | `--include-tags <tags>`  | Only include these HTML tags                                     |
 | `--exclude-tags <tags>`  | Exclude these HTML tags                                          |
+| `--redact-pii`           | Redact personally identifiable information from output           |
 | `-o, --output <path>`    | Output file path                                                 |
 
 ## Tips

--- a/src/__tests__/commands/scrape.test.ts
+++ b/src/__tests__/commands/scrape.test.ts
@@ -350,6 +350,22 @@ describe('executeScrape', () => {
       });
     });
 
+    it('should include redactPII when provided', async () => {
+      const mockResponse = { markdown: '# Test' };
+      mockClient.scrape.mockResolvedValue(mockResponse);
+
+      await executeScrape({
+        url: 'https://example.com',
+        redactPII: true,
+      });
+
+      expect(mockClient.scrape).toHaveBeenCalledWith('https://example.com', {
+        formats: ['markdown'],
+        integration: 'cli',
+        redactPII: true,
+      });
+    });
+
     it('should not include location parameter when not provided', async () => {
       const mockResponse = { markdown: '# Test' };
       mockClient.scrape.mockResolvedValue(mockResponse);

--- a/src/__tests__/utils/options.test.ts
+++ b/src/__tests__/utils/options.test.ts
@@ -304,6 +304,17 @@ describe('Option Parsing Utilities', () => {
       expect(result.timing).toBe(true);
     });
 
+    it('should parse redactPii option from the CLI flag', () => {
+      const options = {
+        url: 'https://example.com',
+        redactPii: true,
+      };
+
+      const result = parseScrapeOptions(options);
+
+      expect(result.redactPII).toBe(true);
+    });
+
     it('should handle undefined format', () => {
       const options = {
         url: 'https://example.com',
@@ -328,6 +339,7 @@ describe('Option Parsing Utilities', () => {
         output: '.firecrawl/output.json',
         pretty: true,
         timing: true,
+        redactPii: true,
       };
 
       const result = parseScrapeOptions(options);
@@ -345,6 +357,7 @@ describe('Option Parsing Utilities', () => {
         output: '.firecrawl/output.json',
         pretty: true,
         timing: true,
+        redactPII: true,
       });
     });
 

--- a/src/commands/scrape.ts
+++ b/src/commands/scrape.ts
@@ -137,6 +137,10 @@ export async function executeScrape(
     scrapeParams.lockdown = true;
   }
 
+  if (options.redactPII) {
+    scrapeParams.redactPII = true;
+  }
+
   // Execute scrape with timing - only wrap the scrape call in try-catch
   const requestStartTime = Date.now();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,6 +371,11 @@ function createScrapeCommand(): Command {
       'Load existing profile data without saving changes (default: saves changes)'
     )
     .option('--lockdown', 'Enable lockdown mode for the scrape', false)
+    .option(
+      '--redact-pii',
+      'Redact personally identifiable information from returned content',
+      false
+    )
     .option('--schema <json>', 'JSON schema for structured extraction')
     .option('--schema-file <path>', 'Path to JSON schema file')
     .option('--actions <json>', 'JSON actions array to run during scrape')

--- a/src/types/scrape.ts
+++ b/src/types/scrape.ts
@@ -70,6 +70,8 @@ export interface ScrapeOptions {
   };
   /** Enable lockdown mode for the scrape */
   lockdown?: boolean;
+  /** Redact personally identifiable information from returned content */
+  redactPII?: boolean;
 }
 
 export interface ScrapeResult {

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -122,5 +122,6 @@ export function parseScrapeOptions(options: any): ScrapeOptions {
     query: options.query,
     profile,
     lockdown: options.lockdown,
+    redactPII: options.redactPii ?? options.redactPII,
   };
 }


### PR DESCRIPTION
## Summary

This change adds a `--redact-pii` flag to the scrape command and forwards it to the Firecrawl API as `redactPII: true`. It also updates the CLI README, bundled scrape skill docs, and tests so CLI users can enable PII redaction with a native kebab-case flag while the API receives the existing camelCase option.
