### PR TITLE
fix(deps): stabilize pnpm global install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "@inquirer/prompts": "^8.2.1",
     "firecrawl": "4.24.0",
-    "commander": "^14.0.2"
+    "commander": "^14.0.2",
+    "zod-to-json-schema": "3.24.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       firecrawl:
         specifier: 4.24.0
         version: 4.24.0
+      zod-to-json-schema:
+        specifier: 3.24.6
+        version: 3.24.6(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -1047,10 +1050,10 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+  zod-to-json-schema@3.24.6:
+    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
-      zod: ^3.25 || ^4
+      zod: ^3.24.1
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -1552,7 +1555,7 @@ snapshots:
       axios: 1.15.2
       typescript-event-target: 1.1.2
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
       - debug
 
@@ -1894,7 +1897,7 @@ snapshots:
 
   yaml@2.8.2: {}
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Summary

Pins `zod-to-json-schema` to `3.24.6` from the CLI package so pnpm global installs cannot float the Firecrawl SDK dependency to `3.25.x` while reusing an older `zod@3.24.x` from the global environment. This prevents the `ERR_PACKAGE_PATH_NOT_EXPORTED` crash from issue #127 while keeping the dependency within the SDK's declared `^3.23.0` range.