### PR TITLE
docs(skill): note keyless free tier fallback in CLI skill

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -17,7 +17,7 @@ If the task is to integrate Firecrawl into an application, add `FIRECRAWL_API_KE
 
 ## Prerequisites
 
-Must be installed and authenticated. Check with `firecrawl --status`.
+Must be installed. Check with `firecrawl --status`.
 
 ```
   🔥 firecrawl cli v1.8.0
@@ -29,6 +29,8 @@ Must be installed and authenticated. Check with `firecrawl --status`.
 
 - **Concurrency**: Max parallel jobs. Run parallel operations up to this limit.
 - **Credits**: Remaining API credits. Each operation consumes credits.
+
+Authenticating gives the best results. Prefer a free account via `firecrawl init --browser` (browser login) or a `FIRECRAWL_API_KEY` whenever the human can sign up. If you cannot obtain a key and the human cannot sign up, you can still search, scrape, and interact without an API key on the keyless free tier (rate-limited). See [agent onboarding](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for the full set of onboarding paths.
 
 If not ready, see [rules/install.md](rules/install.md). For output handling guidelines, see [rules/security.md](rules/security.md).
 

--- a/skills/firecrawl-cli/rules/install.md
+++ b/skills/firecrawl-cli/rules/install.md
@@ -74,6 +74,8 @@ Ask the user how they'd like to authenticate:
 1. **Login with browser (Recommended)** - Run `firecrawl login --browser`
 2. **Enter API key manually** - Run `firecrawl login --api-key "<key>"` with a key from firecrawl.dev
 
+If you cannot obtain a key and the user cannot sign up, search, scrape, and interact still work without an API key on the keyless free tier (rate-limited). Browser login or an API key remains preferred for the best results. See [agent onboarding](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for the full set of onboarding paths.
+
 ### Command not found
 
 If `firecrawl` is not found after installation:


### PR DESCRIPTION
## Why

The installed `firecrawl-cli` skill told agents they "must be installed and authenticated" before doing any work. That does not match the CLI's actual behavior: `search`, `scrape`, and `interact` already run without an API key when no key is set. Agents that read the local skills after `init` were being told to block on authentication that the code does not require, so a keyless agent could wrongly conclude it cannot proceed.

This PR fixes the docs mismatch only. No CLI implementation changes.

## Summary

- `skills/firecrawl-cli/SKILL.md`: reworded Prerequisites so it is no longer API-key-only. Browser login (`firecrawl init --browser`) and a `FIRECRAWL_API_KEY` remain the preferred, conversion-first setup. Added a short fallback noting that search, scrape, and interact work without an API key on the keyless free tier (rate-limited), with a link to the canonical agent onboarding skill for full onboarding paths.
- `skills/firecrawl-cli/rules/install.md`: added the same fallback note in the Authentication section, after the browser/API key options. Browser login stays recommended.

Both notes point to https://www.firecrawl.dev/agent-onboarding/SKILL.md rather than duplicating onboarding content. The existing authenticated flow is preserved.

## Test Plan

- Verified keyless behavior live: ran `firecrawl scrape` with no API key set and it succeeded, confirming the documented fallback matches code.
- `git diff` scanned for forbidden terms (credit counts, "per IP", "credits/mo", rate-limit mechanics) — none present.
- Confirmed no em dashes were added (flag matches like `--status`/`--browser` are pre-existing CLI flags, not prose).
- Confirmed only the two intended skill files changed; no implementation, build, or other skill packages touched.