### PR TITLE
fix(crawl): keep wait polling in seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.19.18",
+  "version": "1.19.19",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/commands/crawl.test.ts
+++ b/src/__tests__/commands/crawl.test.ts
@@ -343,7 +343,7 @@ describe('executeCrawl', () => {
       expect(mockClient.crawl).toHaveBeenCalledWith(
         'https://example.com',
         expect.objectContaining({
-          pollInterval: 5000, // Default poll interval
+          pollInterval: 5, // SDK waiter expects seconds
         })
       );
       expect(result).toEqual({
@@ -371,7 +371,7 @@ describe('executeCrawl', () => {
       expect(mockClient.crawl).toHaveBeenCalledWith(
         'https://example.com',
         expect.objectContaining({
-          pollInterval: 10000, // Converted to milliseconds
+          pollInterval: 10,
         })
       );
     });
@@ -395,7 +395,7 @@ describe('executeCrawl', () => {
       expect(mockClient.crawl).toHaveBeenCalledWith(
         'https://example.com',
         expect.objectContaining({
-          timeout: 300000, // Converted to milliseconds
+          timeout: 300,
         })
       );
     });
@@ -422,8 +422,8 @@ describe('executeCrawl', () => {
       expect(mockClient.crawl).toHaveBeenCalledWith(
         'https://example.com',
         expect.objectContaining({
-          pollInterval: 5000,
-          timeout: 600000,
+          pollInterval: 5,
+          timeout: 600,
           limit: 50,
           maxDiscoveryDepth: 2,
         })
@@ -488,6 +488,9 @@ describe('executeCrawl', () => {
       const result = await crawlPromise;
 
       expect(mockClient.startCrawl).toHaveBeenCalledTimes(1);
+      const [, startOptions] = mockClient.startCrawl.mock.calls[0];
+      expect(startOptions).not.toHaveProperty('pollInterval');
+      expect(startOptions).not.toHaveProperty('timeout');
       expect(mockClient.getCrawlStatus).toHaveBeenCalledTimes(2);
       expect(result.success).toBe(true);
       if (result.success && 'data' in result) {

--- a/src/commands/crawl.ts
+++ b/src/commands/crawl.ts
@@ -132,16 +132,10 @@ export async function executeCrawl(
 
     // If wait mode, use the convenience crawl method with polling
     if (wait) {
-      // Set polling options
-      if (pollInterval !== undefined) {
-        crawlOptions.pollInterval = pollInterval * 1000; // Convert to milliseconds
-      } else {
-        // Default poll interval: 5 seconds
-        crawlOptions.pollInterval = 5000;
-      }
-      if (timeout !== undefined) {
-        crawlOptions.timeout = timeout * 1000; // Convert to milliseconds
-      }
+      const waiterOptions = {
+        pollInterval: pollInterval ?? 5,
+        ...(timeout !== undefined ? { timeout } : {}),
+      };
 
       // Show progress if requested - use custom polling for better UX
       if (options.progress) {
@@ -153,9 +147,9 @@ export async function executeCrawl(
         process.stderr.write(`Job ID: ${jobId}\n`);
 
         // Poll for status with progress updates
-        const pollMs = crawlOptions.pollInterval || 5000;
+        const pollMs = waiterOptions.pollInterval * 1000;
         const startTime = Date.now();
-        const timeoutMs = timeout ? timeout * 1000 : undefined;
+        const timeoutMs = timeout !== undefined ? timeout * 1000 : undefined;
 
         while (true) {
           await new Promise((resolve) => setTimeout(resolve, pollMs));
@@ -190,7 +184,10 @@ export async function executeCrawl(
         }
       } else {
         // Use SDK's built-in polling (no progress display)
-        const crawlJob = await app.crawl(urlOrJobId, crawlOptions);
+        const crawlJob = await app.crawl(urlOrJobId, {
+          ...crawlOptions,
+          ...waiterOptions,
+        });
         return {
           success: true,
           data: crawlJob,


### PR DESCRIPTION
## Summary
- Keep `firecrawl crawl --wait` SDK waiter options in seconds instead of milliseconds.
- Keep `--wait --progress` millisecond conversion local to its custom polling loop.
- Bump `firecrawl-cli` to `1.19.19`.

## Why
The bundled `firecrawl` SDK multiplies `pollInterval` and `timeout` by 1000 internally when waiting for crawl completion. The CLI was already multiplying those values before calling `app.crawl`, so `--poll-interval 5` became roughly 83 minutes between status checks in non-progress wait mode.

Fixes firecrawl/firecrawl#3373

## Test plan
- `pnpm exec vitest run src/__tests__/commands/crawl.test.ts`
- `pnpm run build`
- `pnpm test`
- `pnpm run format:check`