### PR TITLE
fix(cli): tag research requests with integration

### DIFF
--- a/src/commands/research.ts
+++ b/src/commands/research.ts
@@ -36,8 +36,15 @@ function appendParam(
 }
 
 function withQuery(path: string, params: URLSearchParams): string {
+  if (!params.has('integration')) {
+    params.set('integration', 'cli');
+  }
   const qs = params.toString();
   return qs ? `${path}?${qs}` : path;
+}
+
+function withIntegration(path: string): string {
+  return withQuery(path, new URLSearchParams());
 }
 
 async function getResearch<T>(
@@ -218,7 +225,7 @@ export async function handleInspectPaperCommand(
 ): Promise<void> {
   try {
     const data = await getResearch<{ paper?: PaperHit }>(
-      `${BASE}/papers/${encodeURIComponent(options.paperId)}`,
+      withIntegration(`${BASE}/papers/${encodeURIComponent(options.paperId)}`),
       options
     );
     writeResearchOutput(data, fmtPaperMetadata(data.paper), options);


### PR DESCRIPTION
## Summary

- Add `integration=cli` to research command GET request query strings.
- Ensure the inspect-paper research endpoint is tagged even when it has no other query parameters.

## Validation

- `pnpm type-check`
- `pnpm format:check`
- `pnpm test`
