### PR TITLE
Clarify monitor target modes + dashboard link on create

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.19.20",
+  "version": "1.19.21",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/skills/firecrawl-monitor/SKILL.md
+++ b/skills/firecrawl-monitor/SKILL.md
@@ -13,6 +13,17 @@ Detect when content on a website changes and get notified by webhook or email. E
 
 Monitors come in two flavors: **page monitors** watch URLs you already have (a page, a list, or a whole site via crawl) for changes, and **web monitors** watch the whole web via search for _new_ results that match a goal — see [Web monitors](#web-monitors-monitor-the-web).
 
+**Pick a target mode** by what you're watching:
+
+| Mode        | Flags                          | Watches                                                |
+| ----------- | ------------------------------ | ------------------------------------------------------ |
+| Single page | `--page <url>`                 | one URL, for changes                                   |
+| URL batch   | `--scrape-urls <url,url,...>`  | several URLs, for changes                              |
+| Whole site  | `--crawl-url <root-url>`       | every page a crawl discovers, for changes              |
+| Web search  | `--queries <q,...>` + `--goal` | the **whole web**, for _new_ results matching the goal |
+
+The first three watch URLs you already have. **Web search** is the odd one out — there's no fixed URL; it runs your queries each check and alerts on results it hasn't seen before. `--goal` is required with `--queries`. (See [Web monitors](#web-monitors-monitor-the-web).)
+
 ## When to use
 
 - The user wants to know **when** something changes — and be **notified about it** — not just read what the page says right now

--- a/src/commands/monitor.ts
+++ b/src/commands/monitor.ts
@@ -127,6 +127,21 @@ function fail(error: unknown): never {
 }
 
 /**
+ * Firecrawl Cloud web dashboard URL for a monitor, used to point users at the
+ * place they can inspect checks and tweak config. Returns null for self-hosted
+ * APIs, which have no web dashboard.
+ */
+function monitorDashboardUrl(
+  id: string,
+  apiUrl: string | undefined
+): string | null {
+  const url = apiUrl || getConfig().apiUrl || DEFAULT_API_URL;
+  return /api\.firecrawl\.dev/i.test(url)
+    ? `https://www.firecrawl.dev/app/monitoring/${id}`
+    : null;
+}
+
+/**
  * Build the request body for `monitor create` from CLI flags.
  *
  * For full control, callers can pass a JSON file path positionally or pipe
@@ -310,6 +325,19 @@ export function createMonitorCommand(): Command {
         '--goal <text>',
         'Plain-language goal for the AI change judge (auto-enables the judge)'
       )
+      .addHelpText(
+        'after',
+        `
+Target modes (choose one per monitor):
+  --page <url>                    Watch a single page for changes
+  --scrape-urls <url,url,...>     Watch a batch of pages for changes
+  --crawl-url <root-url>          Watch a whole site — crawls and diffs every page each check
+  --queries <query,...> + --goal  Watch the web via search — alerts on NEW results matching --goal
+
+The first three watch URLs you give it for changes. --queries instead searches the
+whole web each check and alerts on new results matching your --goal (required with --queries).
+`
+      )
   ).action(async (file: string | undefined, options) => {
     try {
       const fromJson = await readJsonPayload(file);
@@ -339,6 +367,16 @@ export function createMonitorCommand(): Command {
         body,
       });
       emit(payload, options);
+      // Point the user at the dashboard + a smoke-test. Only when interactive,
+      // so stdout pipes and `--output` files stay clean for scripting.
+      const createdId = (payload as { data?: { id?: string } })?.data?.id;
+      if (createdId && process.stdout.isTTY) {
+        const link = monitorDashboardUrl(createdId, options.apiUrl);
+        const hints = [`\n  Monitor created · ${createdId}`];
+        if (link) hints.push(`  Open in dashboard:  ${link}`);
+        hints.push(`  Trigger a check:    firecrawl monitor run ${createdId}`);
+        process.stderr.write(hints.join('\n') + '\n');
+      }
     } catch (err) {
       fail(err);
     }


### PR DESCRIPTION
Follow-up UX polish on `firecrawl monitor` (the search-target support shipped in #142).

### `monitor create --help` — clearer target modes
Adds a **Target modes** section so it's obvious which flag does what:
```
--page <url>                    Watch a single page for changes
--scrape-urls <url,url,...>     Watch a batch of pages for changes
--crawl-url <root-url>          Watch a whole site — crawls and diffs every page each check
--queries <query,...> + --goal  Watch the web via search — alerts on NEW results matching --goal
```

### Dashboard link on create
After a successful create, prints the Cloud dashboard link + a run-now hint to **stderr** — interactive only (`process.stdout.isTTY`), so pipes and `--output` stay clean for scripting:
```
  Monitor created · 019f05af-9bf6-...
  Open in dashboard:  https://www.firecrawl.dev/app/monitoring/019f05af-9bf6-...
  Trigger a check:    firecrawl monitor run 019f05af-9bf6-...
```
(Skipped for self-hosted APIs, which have no web dashboard.)

### Skill clarity
`firecrawl-monitor` SKILL.md gains a **target-mode table** so agents pick the right flags up front (single page / URL batch / whole-site crawl / web search).

Version → `1.19.21`. tsc clean, 4/4 monitor tests pass.