### PR TITLE
fix(skills): default skills install to detected agents instead of --all

### DIFF
--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -1,14 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execSync } from 'child_process';
 import { handleInitCommand } from '../../commands/init';
+import { detectInstalledAgentNames } from '../../commands/skills-native';
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
 }));
 
+vi.mock('../../commands/skills-native', () => ({
+  hasNpx: () => true,
+  installSkillsNative: vi.fn(),
+  detectInstalledAgentNames: vi.fn(() => []),
+}));
+
 describe('handleInitCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(detectInstalledAgentNames).mockReturnValue([]);
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -17,7 +25,7 @@ describe('handleInitCommand', () => {
     vi.restoreAllMocks();
   });
 
-  it('installs skills from all repos globally across all detected agents in non-interactive mode', async () => {
+  it('falls back to installing across every known agent when none is detected', async () => {
     await handleInitCommand({
       yes: true,
       skipInstall: true,
@@ -34,6 +42,24 @@ describe('handleInitCommand', () => {
     );
     expect(execSync).toHaveBeenCalledWith(
       'npx -y skills add firecrawl/firecrawl-workflows --full-depth --global --all --yes',
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  });
+
+  it('scopes non-interactive skills install to the detected agents when none is explicitly provided', async () => {
+    vi.mocked(detectInstalledAgentNames).mockReturnValue([
+      'claude-code',
+      'cursor',
+    ]);
+
+    await handleInitCommand({
+      yes: true,
+      skipInstall: true,
+      skipAuth: true,
+    });
+
+    expect(execSync).toHaveBeenCalledWith(
+      'npx -y skills add firecrawl/cli --full-depth --global --yes --agent claude-code cursor',
       expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
     );
   });

--- a/src/__tests__/commands/setup.test.ts
+++ b/src/__tests__/commands/setup.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execSync } from 'child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import {
@@ -41,17 +41,42 @@ describe('handleSetupCommand', () => {
     vi.restoreAllMocks();
   });
 
-  it('installs core and build skills globally across all detected agents by default', async () => {
-    await handleSetupCommand('skills', {});
+  it('falls back to installing across every known agent when none is detected', async () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), 'firecrawl-setup-test-'));
+    process.env.HOME = home;
 
-    expect(execSync).toHaveBeenCalledWith(
-      'npx -y skills add firecrawl/cli --full-depth --global --all',
-      expect.objectContaining({ stdio: 'inherit' })
-    );
-    expect(execSync).toHaveBeenCalledWith(
-      'npx -y skills add firecrawl/skills --full-depth --global --all',
-      expect.objectContaining({ stdio: 'inherit' })
-    );
+    try {
+      await handleSetupCommand('skills', {});
+
+      expect(execSync).toHaveBeenCalledWith(
+        'npx -y skills add firecrawl/cli --full-depth --global --all',
+        expect.objectContaining({ stdio: 'inherit' })
+      );
+      expect(execSync).toHaveBeenCalledWith(
+        'npx -y skills add firecrawl/skills --full-depth --global --all',
+        expect.objectContaining({ stdio: 'inherit' })
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('scopes skills install to the detected agents when none is explicitly provided', async () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), 'firecrawl-setup-test-'));
+    mkdirSync(path.join(home, '.claude'));
+    mkdirSync(path.join(home, '.cursor'));
+    process.env.HOME = home;
+
+    try {
+      await handleSetupCommand('skills', {});
+
+      expect(execSync).toHaveBeenCalledWith(
+        'npx -y skills add firecrawl/cli --full-depth --global --agent claude-code cursor',
+        expect.objectContaining({ stdio: 'inherit' })
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('installs core and build skills globally for a specific agent without using --all', async () => {
@@ -68,12 +93,19 @@ describe('handleSetupCommand', () => {
   });
 
   it('installs workflow skills as a separate setup option', async () => {
-    await handleSetupCommand('workflows', {});
+    const home = mkdtempSync(path.join(os.tmpdir(), 'firecrawl-setup-test-'));
+    process.env.HOME = home;
 
-    expect(execSync).toHaveBeenCalledWith(
-      'npx -y skills add firecrawl/firecrawl-workflows --full-depth --global --all',
-      expect.objectContaining({ stdio: 'inherit' })
-    );
+    try {
+      await handleSetupCommand('workflows', {});
+
+      expect(execSync).toHaveBeenCalledWith(
+        'npx -y skills add firecrawl/firecrawl-workflows --full-depth --global --all',
+        expect.objectContaining({ stdio: 'inherit' })
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('installs all skill repos for Codex non-interactively', async () => {
@@ -107,22 +139,29 @@ describe('handleSetupCommand', () => {
   });
 
   it('installs the default setup bundle with --yes', async () => {
-    await handleSetupCommand(undefined, { yes: true });
+    const home = mkdtempSync(path.join(os.tmpdir(), 'firecrawl-setup-test-'));
+    process.env.HOME = home;
 
-    expect(execSync).toHaveBeenCalledWith(
-      'npx -y skills add firecrawl/cli --full-depth --global --all --yes',
-      expect.objectContaining({ stdio: 'inherit' })
-    );
-    expect(execSync).toHaveBeenCalledWith(
-      'npx -y skills add firecrawl/skills --full-depth --global --all --yes',
-      expect.objectContaining({ stdio: 'inherit' })
-    );
-    expect(execSync).toHaveBeenCalledWith(
-      'npx -y add-mcp "https://mcp.firecrawl.dev/fc-test-key/v2/mcp" --name firecrawl --transport http --global --yes',
-      expect.objectContaining({
-        stdio: 'inherit',
-      })
-    );
+    try {
+      await handleSetupCommand(undefined, { yes: true });
+
+      expect(execSync).toHaveBeenCalledWith(
+        'npx -y skills add firecrawl/cli --full-depth --global --all --yes',
+        expect.objectContaining({ stdio: 'inherit' })
+      );
+      expect(execSync).toHaveBeenCalledWith(
+        'npx -y skills add firecrawl/skills --full-depth --global --all --yes',
+        expect.objectContaining({ stdio: 'inherit' })
+      );
+      expect(execSync).toHaveBeenCalledWith(
+        'npx -y add-mcp "https://mcp.firecrawl.dev/fc-test-key/v2/mcp" --name firecrawl --transport http --global --yes',
+        expect.objectContaining({
+          stdio: 'inherit',
+        })
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('requires a subcommand for bare setup in non-interactive mode', async () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,6 +12,7 @@ import {
   ALL_SKILL_REPOS,
   buildSkillsInstallArgs,
   cleanNpmEnv,
+  resolveSkillsTarget,
   SKILL_REPOS,
   WORKFLOW_SKILL_REPOS,
 } from './skills-install';
@@ -134,7 +135,7 @@ async function installSkillRepoQuiet(
   if (hasNpx()) {
     const args = buildSkillsInstallArgs({
       repo,
-      agent: options.agent,
+      ...resolveSkillsTarget(options),
       yes: options.yes || options.all || true,
       global: true,
       includeNpxYes: true,

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -13,6 +13,7 @@ import { getApiKey } from '../utils/config';
 import {
   buildSkillsInstallArgs,
   cleanNpmEnv,
+  resolveSkillsTarget,
   SKILL_REPOS,
   WORKFLOW_SKILL_REPOS,
 } from './skills-install';
@@ -323,7 +324,7 @@ async function installSkills(
     if (hasNpx()) {
       const args = buildSkillsInstallArgs({
         repo,
-        agent: options.agent,
+        ...resolveSkillsTarget(options),
         global: true,
         yes: options.yes,
         includeNpxYes: true,

--- a/src/commands/skills-install.ts
+++ b/src/commands/skills-install.ts
@@ -12,6 +12,8 @@
  * installs core/build skills, and `firecrawl setup workflows` installs workflow
  * skills.
  */
+import { detectInstalledAgentNames } from './skills-native';
+
 export const SKILL_REPOS = ['firecrawl/cli', 'firecrawl/skills'] as const;
 
 export const WORKFLOW_SKILL_REPOS = ['firecrawl/firecrawl-workflows'] as const;
@@ -22,13 +24,34 @@ export const ALL_SKILL_REPOS = [
 ] as const;
 
 export interface SkillsInstallCommandOptions {
-  agent?: string;
+  agent?: string | string[];
   all?: boolean;
   yes?: boolean;
   global?: boolean;
   includeNpxYes?: boolean;
   /** Repo to install from (defaults to firecrawl/cli) */
   repo?: string;
+}
+
+/**
+ * Resolve which agent(s) to install into.
+ *
+ * An explicit `--agent` or `--all` wins. Otherwise, install only into agents
+ * actually detected on this machine — installing into every agent the
+ * `skills` package knows about (most of which the user has never heard of)
+ * is surprising and litters $HOME with dozens of unused directories. Falls
+ * back to `--all` only if detection finds nothing, so non-interactive runs
+ * never end up with no target at all.
+ */
+export function resolveSkillsTarget(options: {
+  agent?: string;
+  all?: boolean;
+}): Pick<SkillsInstallCommandOptions, 'agent' | 'all'> {
+  if (options.agent) return { agent: options.agent };
+  if (options.all) return { all: true };
+
+  const detected = detectInstalledAgentNames();
+  return detected.length > 0 ? { agent: detected } : { all: true };
 }
 
 export function buildSkillsInstallArgs(
@@ -46,8 +69,7 @@ export function buildSkillsInstallArgs(
     args.push('--global');
   }
 
-  const installToAllAgents = options.agent ? false : (options.all ?? true);
-  if (installToAllAgents) {
+  if (options.all) {
     args.push('--all');
   }
 
@@ -55,8 +77,13 @@ export function buildSkillsInstallArgs(
     args.push('--yes');
   }
 
-  if (options.agent) {
-    args.push('--agent', options.agent);
+  const agents = options.agent
+    ? Array.isArray(options.agent)
+      ? options.agent
+      : [options.agent]
+    : [];
+  if (agents.length > 0) {
+    args.push('--agent', ...agents);
   }
 
   return args;

--- a/src/commands/skills-native.ts
+++ b/src/commands/skills-native.ts
@@ -275,6 +275,11 @@ function detectInstalledAgents(): AgentConfig[] {
   });
 }
 
+/** Names of agents whose config directory already exists in $HOME. */
+export function detectInstalledAgentNames(): string[] {
+  return detectInstalledAgents().map((agent) => agent.name);
+}
+
 /** Check if git is available */
 function hasGit(): boolean {
   try {


### PR DESCRIPTION
## Summary

Fixes #149.

`firecrawl init` and `firecrawl setup skills` always appended `--all` to the
underlying `npx skills add` call, which installs skills into every agent the
`skills` package (vercel-labs/skills) knows about — 60+ agents — regardless
of whether the agent is actually present on the machine. In practice this
litters `$HOME` with dozens of unused hidden directories (`.openclaw`,
`.qwen`, `.tabnine`, `.kiro`, `.trae`, `.vibe`, ...) for tools the user never
installed.

The codebase already has the right detection logic —
`detectInstalledAgents()` in `src/commands/skills-native.ts` — but it was
only reachable from the native no-npx fallback path, never from the default
`npx`-based install path that basically everyone hits.

## Changes

- `skills-native.ts`: export `detectInstalledAgentNames()`, a thin wrapper
  around the existing detection.
- `skills-install.ts`: add `resolveSkillsTarget()` — explicit `--agent` or
  `--all` still win, otherwise install is scoped to agents actually detected
  on the machine, falling back to `--all` only if nothing is detected (so a
  non-interactive run never ends up with no target). `buildSkillsInstallArgs`
  no longer defaults to `--all` on its own, and `agent` can now be a list so
  multiple detected agents can be passed in one `npx skills add` call.
- `init.ts` / `setup.ts`: both entry points now call `resolveSkillsTarget`
  instead of leaving the `--all` default implicit.
- Updated `init.test.ts` / `setup.test.ts` to cover the new default
  (detection-based) behavior and the fallback-to-`--all` case, isolating
  `$HOME` per test (`mkdtempSync`) so results don't depend on the machine
  running the suite.

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run` — 363/363 tests pass
- [x] Manually verified on a real machine: ran the built CLI's
      `init -y --skip-install --skip-auth` against a `$HOME` containing only
      `~/.claude`; confirmed skills were installed into `~/.claude/skills`
      and `~/.agents/skills` only, with none of the other 60+ agent
      directories created.