### PR TITLE
Document scrape freshness and cache metadata

### DIFF
--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -51,7 +51,17 @@ firecrawl scrape "https://example.com/pricing" --query "What is the enterprise p
 | `--include-tags <tags>`  | Only include these HTML tags                                     |
 | `--exclude-tags <tags>`  | Exclude these HTML tags                                          |
 | `--redact-pii`           | Redact personally identifiable information from output           |
+| `--max-age <milliseconds>` | Maximum age of cached content. Use `0` for final freshness checks |
+| `--json`                  | Emit JSON so metadata such as `metadata.cache` can be inspected  |
 | `-o, --output <path>`    | Output file path                                                 |
+
+
+## Freshness and cache provenance
+
+- Use `--max-age 0` when the scrape is a final verification before an action that depends on current state. It bypasses Firecrawl cache and is slower/more failure-prone than allowing cache.
+- Use `--json` when you need to inspect metadata. An attested Firecrawl-index cache hit includes `metadata.cache.source = "firecrawl-index"` and `metadata.cache.cachedAt`.
+- If `metadata.cache` is absent, do not infer miss, fresh scrape, bypass, or source-page liveness. It only means cache provenance was not attested.
+- For job postings, event pages, inventory, and other stateful records, verify the business object itself before acting: prefer an ATS/source API when available, or check for active apply buttons, closed labels, canonical IDs, and redirects in the fresh content. HTTP 200 and rendered HTML are not enough.
 
 ## Tips
 

--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -51,17 +51,16 @@ firecrawl scrape "https://example.com/pricing" --query "What is the enterprise p
 | `--include-tags <tags>`  | Only include these HTML tags                                     |
 | `--exclude-tags <tags>`  | Exclude these HTML tags                                          |
 | `--redact-pii`           | Redact personally identifiable information from output           |
-| `--max-age <milliseconds>` | Maximum age of cached content. Use `0` for final freshness checks |
+| `--max-age <milliseconds>` | Maximum age of cached content. Use `0` to request fresh retrieval |
 | `--json`                  | Emit JSON so metadata such as `metadata.cache` can be inspected  |
 | `-o, --output <path>`    | Output file path                                                 |
 
-
 ## Freshness and cache provenance
 
-- Use `--max-age 0` when the scrape is a final verification before an action that depends on current state. It bypasses Firecrawl cache and is slower/more failure-prone than allowing cache.
+- Use `--max-age 0` to request a fresh retrieval path before an action that depends on current state. It skips Firecrawl's index cache and can be slower or more failure-prone than allowing cache.
 - Use `--json` when you need to inspect metadata. An attested Firecrawl-index cache hit includes `metadata.cache.source = "firecrawl-index"` and `metadata.cache.cachedAt`.
 - If `metadata.cache` is absent, do not infer miss, fresh scrape, bypass, or source-page liveness. It only means cache provenance was not attested.
-- For job postings, event pages, inventory, and other stateful records, verify the business object itself before acting: prefer an ATS/source API when available, or check for active apply buttons, closed labels, canonical IDs, and redirects in the fresh content. HTTP 200 and rendered HTML are not enough.
+- For job postings, event pages, inventory, and other stateful records, verify the business object itself before acting: prefer an ATS/source API when available, or check the returned content for active apply buttons, closed labels, canonical IDs, and redirects. HTTP 200 and rendered HTML are not enough.
 
 ## Tips
 


### PR DESCRIPTION
## Summary
- document existing `firecrawl scrape --max-age` and `--json` in the scrape skill
- add fresh-retrieval/cache provenance guidance for final verification scrapes
- add job/ATS liveness guidance for agent workflows

## Root cause / behavior change
CLI agents could already pass `--max-age`, but the skill did not teach when to request a fresh retrieval path or how to inspect cache provenance. The scrape skill now makes the final-verification pattern explicit without treating retrieval freshness as source-object liveness.

## Validation
- scoped grep for `--max-age`, `--json`, `metadata.cache`, ATS/liveness guidance ✅
- `git diff --check` ✅
- GitHub Actions ✅: tests, macOS/Linux/Windows binary tests, and macOS/Linux/Windows npm package smoke tests
