### PR TITLE
Add project-local CLI routing for skills-based setup

### DIFF
--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -1,10 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execSync } from 'child_process';
 import { handleInitCommand } from '../../commands/init';
+import { installCliRouterCard } from '../../utils/router-card';
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
 }));
+
+vi.mock('../../utils/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/auth')>();
+  return { ...actual, isAuthenticated: vi.fn(() => true) };
+});
+
+vi.mock('../../utils/router-card', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../utils/router-card')>();
+  return {
+    ...actual,
+    installCliRouterCard: vi.fn(() => ({
+      path: '/workspace/AGENTS.md',
+      changed: true,
+      version: 2,
+      sha256:
+        'f781e09b71c0d7f5a60f5bbf37a0c656cf30ade2876212a5f0dcde6bebaad995',
+    })),
+    resolveRouterCardProject: vi.fn((project: string) => project),
+  };
+});
 
 describe('handleInitCommand', () => {
   beforeEach(() => {
@@ -58,5 +80,42 @@ describe('handleInitCommand', () => {
       'npx -y skills add firecrawl/firecrawl-workflows --full-depth --global --yes --agent cursor',
       expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
     );
+  });
+
+  it('installs the CLI-only router card after the selected agent skills', async () => {
+    await handleInitCommand({
+      yes: true,
+      skipInstall: true,
+      skipAuth: true,
+      agent: 'codex',
+      project: '/workspace',
+      routerCard: true,
+    });
+
+    expect(installCliRouterCard).toHaveBeenCalledWith('codex', '/workspace');
+  });
+
+  it('rejects router-card setup without an explicit project or skills', async () => {
+    await expect(
+      handleInitCommand({
+        yes: true,
+        skipInstall: true,
+        skipAuth: true,
+        agent: 'codex',
+        routerCard: true,
+      })
+    ).rejects.toThrow('requires an explicit --project');
+
+    await expect(
+      handleInitCommand({
+        yes: true,
+        skipInstall: true,
+        skipAuth: true,
+        skipSkills: true,
+        agent: 'codex',
+        project: '/workspace',
+        routerCard: true,
+      })
+    ).rejects.toThrow('requires skills');
   });
 });

--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -82,17 +82,47 @@ describe('handleInitCommand', () => {
     );
   });
 
-  it('installs the CLI-only router card after the selected agent skills', async () => {
+  it('installs the CLI-only router card by default after eligible project skills setup', async () => {
     await handleInitCommand({
       yes: true,
       skipInstall: true,
       skipAuth: true,
       agent: 'codex',
       project: '/workspace',
-      routerCard: true,
     });
 
     expect(installCliRouterCard).toHaveBeenCalledWith('codex', '/workspace');
+  });
+
+  it('honors the per-run router-card opt-out', async () => {
+    await handleInitCommand({
+      yes: true,
+      skipInstall: true,
+      skipAuth: true,
+      agent: 'codex',
+      project: '/workspace',
+      routerCard: false,
+    });
+
+    expect(installCliRouterCard).not.toHaveBeenCalled();
+  });
+
+  it('does not write routing outside an explicit supported project state', async () => {
+    await handleInitCommand({
+      yes: true,
+      skipInstall: true,
+      skipAuth: true,
+      agent: 'codex',
+    });
+    await handleInitCommand({
+      yes: true,
+      skipInstall: true,
+      skipAuth: true,
+      agent: 'cursor',
+      project: '/workspace',
+    });
+
+    expect(installCliRouterCard).not.toHaveBeenCalled();
   });
 
   it('rejects router-card setup without an explicit project or skills', async () => {

--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -24,6 +24,13 @@ vi.mock('../../utils/router-card', async (importOriginal) => {
       sha256:
         'f781e09b71c0d7f5a60f5bbf37a0c656cf30ade2876212a5f0dcde6bebaad995',
     })),
+    removeRouterCard: vi.fn(() => ({
+      path: '/workspace/AGENTS.md',
+      changed: true,
+      version: 2,
+      sha256:
+        'f781e09b71c0d7f5a60f5bbf37a0c656cf30ade2876212a5f0dcde6bebaad995',
+    })),
     resolveRouterCardProject: vi.fn((project: string) => project),
   };
 });
@@ -105,6 +112,19 @@ describe('handleInitCommand', () => {
     });
 
     expect(installCliRouterCard).not.toHaveBeenCalled();
+  });
+
+  it('removes managed project routing without running onboarding again', async () => {
+    const { removeRouterCard } = await import('../../utils/router-card');
+
+    await handleInitCommand({
+      agent: 'codex',
+      project: '/workspace',
+      removeRouterCard: true,
+    });
+
+    expect(removeRouterCard).toHaveBeenCalledWith('codex', '/workspace');
+    expect(execSync).not.toHaveBeenCalled();
   });
 
   it('does not write routing outside an explicit supported project state', async () => {

--- a/src/__tests__/utils/router-card.test.ts
+++ b/src/__tests__/utils/router-card.test.ts
@@ -14,6 +14,9 @@ import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   addRouterGuidanceToSkillDescription,
+  CLI_ROUTER_CARD,
+  CLI_ROUTER_CARD_SHA256,
+  installCliRouterCard,
   installRouterCard,
   removeRouterCard,
   resolveRouterCardProject,
@@ -49,6 +52,29 @@ describe('router card', () => {
     expect(ROUTER_CARD).toContain('firecrawl_search');
     expect(ROUTER_CARD).toContain('firecrawl_scrape');
     expect(ROUTER_CARD).not.toMatch(/api[_ -]?key|fc-[a-z0-9]|mcp\.firecrawl/i);
+  });
+
+  it('keeps the CLI-only card capability-honest and distinct', () => {
+    expect(CLI_ROUTER_CARD_SHA256).toBe(
+      'f781e09b71c0d7f5a60f5bbf37a0c656cf30ade2876212a5f0dcde6bebaad995'
+    );
+    expect(CLI_ROUTER_CARD).toContain('firecrawl search');
+    expect(CLI_ROUTER_CARD).toContain('firecrawl scrape');
+    expect(CLI_ROUTER_CARD).not.toMatch(
+      /firecrawl_search|firecrawl_scrape|MCP/
+    );
+  });
+
+  it('replaces the managed full-bundle card with the CLI-only card', () => {
+    const root = project();
+    installRouterCard('codex', root);
+    const receipt = installCliRouterCard('codex', root);
+
+    expect(receipt.changed).toBe(true);
+    expect(receipt.sha256).toBe(CLI_ROUTER_CARD_SHA256);
+    expect(readFileSync(path.join(root, 'AGENTS.md'), 'utf8')).toBe(
+      `${CLI_ROUTER_CARD}\n`
+    );
   });
 
   it('does not treat Codex App as the validated Codex CLI surface', () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -967,20 +967,39 @@ export async function handleInitCommand(
 }
 
 async function runNonInteractive(options: InitOptions): Promise<void> {
-  if (options.routerCard && options.skipSkills) {
+  const normalizedAgent = options.agent?.trim().toLowerCase();
+  const routerAgent: RouterCardAgent | undefined =
+    normalizedAgent === 'claude' || normalizedAgent === 'claude-code'
+      ? 'claude'
+      : normalizedAgent === 'codex'
+        ? 'codex'
+        : undefined;
+  const explicitlyEnableRouter = options.routerCard === true;
+  if (explicitlyEnableRouter && options.skipSkills) {
     throw new Error('--router-card requires skills; remove --skip-skills.');
   }
-  if (options.routerCard && !options.agent) {
+  if (explicitlyEnableRouter && !options.agent) {
     throw new Error('--router-card requires --agent claude or --agent codex.');
   }
-  if (options.routerCard && !options.project) {
+  if (explicitlyEnableRouter && !routerAgent) {
+    throw new Error(
+      '--router-card currently supports --agent claude or --agent codex.'
+    );
+  }
+  if (explicitlyEnableRouter && !options.project) {
     throw new Error('--router-card requires an explicit --project <path>.');
   }
+  const routerEligible = Boolean(
+    options.routerCard !== false &&
+    routerAgent &&
+    options.project &&
+    !options.skipSkills
+  );
   const steps: string[] = [];
   if (!options.skipAuth) steps.push('auth');
   if (!options.skipInstall) steps.push('install');
   if (!options.skipSkills) steps.push('skills');
-  if (options.routerCard) steps.push('router');
+  if (routerEligible) steps.push('router');
   const total = steps.length;
   let current = 0;
 
@@ -1067,26 +1086,21 @@ async function runNonInteractive(options: InitOptions): Promise<void> {
     }
   }
 
-  if (options.routerCard) {
-    if (!isAuthenticated()) {
+  if (explicitlyEnableRouter && !isAuthenticated()) {
+    throw new Error(
+      'Router-card setup requires an authenticated Firecrawl CLI.'
+    );
+  }
+
+  if (routerEligible && isAuthenticated()) {
+    if (!routerAgent) {
       throw new Error(
-        'Router-card setup requires an authenticated Firecrawl CLI.'
+        'Router-card setup requires --agent claude or --agent codex.'
       );
     }
-    const normalized = options.agent!.trim().toLowerCase();
-    const agent: RouterCardAgent =
-      normalized === 'claude' || normalized === 'claude-code'
-        ? 'claude'
-        : normalized === 'codex'
-          ? 'codex'
-          : (() => {
-              throw new Error(
-                '--router-card currently supports --agent claude or --agent codex.'
-              );
-            })();
     const project = resolveRouterCardProject(options.project);
     console.log(`${stepLabel()} Configuring project web routing...`);
-    const receipt = installCliRouterCard(agent, project);
+    const receipt = installCliRouterCard(routerAgent, project);
     console.log(
       `${green}✓${reset} ${receipt.changed ? 'Installed' : 'Verified'} Firecrawl CLI router card in ${receipt.path}\n`
     );

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -27,6 +27,7 @@ import {
 } from '../utils/web-defaults';
 import {
   installCliRouterCard,
+  removeRouterCard,
   resolveRouterCardProject,
   type RouterCardAgent,
 } from '../utils/router-card';
@@ -43,6 +44,7 @@ export interface InitOptions {
   browser?: boolean;
   template?: string;
   routerCard?: boolean;
+  removeRouterCard?: boolean;
   project?: string;
 }
 
@@ -932,8 +934,9 @@ export async function handleInitCommand(
   console.log(`  ${orange}🔥 ${bold}firecrawl${reset} ${dim}init${reset}`);
   console.log('');
 
-  // Non-interactive mode (--yes or --all skips all prompts)
-  if (options.yes || options.all) {
+  // Non-interactive mode (--yes or --all skips all prompts). Removal is a
+  // bounded project-state operation and never enters onboarding prompts.
+  if (options.yes || options.all || options.removeRouterCard) {
     await runNonInteractive(options);
     return;
   }
@@ -975,6 +978,22 @@ async function runNonInteractive(options: InitOptions): Promise<void> {
         ? 'codex'
         : undefined;
   const explicitlyEnableRouter = options.routerCard === true;
+  if (explicitlyEnableRouter && options.removeRouterCard) {
+    throw new Error('Cannot combine --router-card with --remove-router-card.');
+  }
+  if (options.removeRouterCard) {
+    if (!routerAgent || !options.project) {
+      throw new Error(
+        '--remove-router-card requires --agent claude or --agent codex and an explicit --project <path>.'
+      );
+    }
+    const project = resolveRouterCardProject(options.project);
+    const receipt = removeRouterCard(routerAgent, project);
+    console.log(
+      `${green}✓${reset} ${receipt.changed ? 'Removed' : 'No managed'} Firecrawl CLI router card in ${receipt.path}\n`
+    );
+    return;
+  }
   if (explicitlyEnableRouter && options.skipSkills) {
     throw new Error('--router-card requires skills; remove --skip-skills.');
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -25,6 +25,11 @@ import {
   WEB_AGENTS,
   type WebAgent,
 } from '../utils/web-defaults';
+import {
+  installCliRouterCard,
+  resolveRouterCardProject,
+  type RouterCardAgent,
+} from '../utils/router-card';
 
 export interface InitOptions {
   global?: boolean;
@@ -37,6 +42,8 @@ export interface InitOptions {
   apiKey?: string;
   browser?: boolean;
   template?: string;
+  routerCard?: boolean;
+  project?: string;
 }
 
 const orange = '\x1b[38;5;208m';
@@ -960,10 +967,20 @@ export async function handleInitCommand(
 }
 
 async function runNonInteractive(options: InitOptions): Promise<void> {
+  if (options.routerCard && options.skipSkills) {
+    throw new Error('--router-card requires skills; remove --skip-skills.');
+  }
+  if (options.routerCard && !options.agent) {
+    throw new Error('--router-card requires --agent claude or --agent codex.');
+  }
+  if (options.routerCard && !options.project) {
+    throw new Error('--router-card requires an explicit --project <path>.');
+  }
   const steps: string[] = [];
   if (!options.skipAuth) steps.push('auth');
   if (!options.skipInstall) steps.push('install');
   if (!options.skipSkills) steps.push('skills');
+  if (options.routerCard) steps.push('router');
   const total = steps.length;
   let current = 0;
 
@@ -1048,6 +1065,31 @@ async function runNonInteractive(options: InitOptions): Promise<void> {
         process.exit(1);
       }
     }
+  }
+
+  if (options.routerCard) {
+    if (!isAuthenticated()) {
+      throw new Error(
+        'Router-card setup requires an authenticated Firecrawl CLI.'
+      );
+    }
+    const normalized = options.agent!.trim().toLowerCase();
+    const agent: RouterCardAgent =
+      normalized === 'claude' || normalized === 'claude-code'
+        ? 'claude'
+        : normalized === 'codex'
+          ? 'codex'
+          : (() => {
+              throw new Error(
+                '--router-card currently supports --agent claude or --agent codex.'
+              );
+            })();
+    const project = resolveRouterCardProject(options.project);
+    console.log(`${stepLabel()} Configuring project web routing...`);
+    const receipt = installCliRouterCard(agent, project);
+    console.log(
+      `${green}✓${reset} ${receipt.changed ? 'Installed' : 'Verified'} Firecrawl CLI router card in ${receipt.path}\n`
+    );
   }
 
   printNextSteps(skillCount);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2158,6 +2158,10 @@ program
     'Explicitly install the project-local CLI router card (requires --agent and --project)'
   )
   .option('--no-router-card', 'Skip project-local routing during this init run')
+  .option(
+    '--remove-router-card',
+    'Remove the managed project-local router card, then exit'
+  )
   .option('--project <path>', 'Project directory for the candidate router card')
   .action(async (template, options) => {
     const globalOptions = program.opts();
@@ -2173,6 +2177,7 @@ program
       skipAuth: options.skipAuth,
       skipSkills: options.skipSkills,
       routerCard: options.routerCard,
+      removeRouterCard: options.removeRouterCard,
       project: options.project,
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2153,6 +2153,11 @@ program
   .option('--skip-install', 'Skip global CLI installation')
   .option('--skip-auth', 'Skip authentication')
   .option('--skip-skills', 'Skip skills installation')
+  .option(
+    '--router-card',
+    'Install the candidate project-local CLI router card (requires --agent and --project)'
+  )
+  .option('--project <path>', 'Project directory for the candidate router card')
   .action(async (template, options) => {
     const globalOptions = program.opts();
     await handleInitCommand({
@@ -2166,6 +2171,8 @@ program
       skipInstall: options.skipInstall,
       skipAuth: options.skipAuth,
       skipSkills: options.skipSkills,
+      routerCard: options.routerCard,
+      project: options.project,
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2155,8 +2155,9 @@ program
   .option('--skip-skills', 'Skip skills installation')
   .option(
     '--router-card',
-    'Install the candidate project-local CLI router card (requires --agent and --project)'
+    'Explicitly install the project-local CLI router card (requires --agent and --project)'
   )
+  .option('--no-router-card', 'Skip project-local routing during this init run')
   .option('--project <path>', 'Project directory for the candidate router card')
   .action(async (template, options) => {
     const globalOptions = program.opts();

--- a/src/utils/router-card.ts
+++ b/src/utils/router-card.ts
@@ -42,16 +42,60 @@ ${END_MARKER}`;
 export const ROUTER_CARD_SHA256 =
   'df867193a6fe011342fce14b770e497cf667ca755e396bb16bbb52c513627951';
 
+export const CLI_ROUTER_CARD_VERSION = 2;
+
+export const CLI_ROUTER_CARD = `${START_MARKER}
+<!-- firecrawl-router-card:version=${CLI_ROUTER_CARD_VERSION};surface=cli -->
+## Firecrawl CLI routing
+
+Use the installed Firecrawl CLI for public-web discovery and retrieval:
+- Search the web with \`firecrawl search "query" --limit 5\`.
+- Read a page with \`firecrawl scrape https://example.com\`.
+- Discover or traverse a site with \`firecrawl map https://example.com\` or \`firecrawl crawl https://example.com --limit 50\`.
+
+Prefer Firecrawl over generic browsing tools when the task needs public web data.
+Respect explicit requests to stay offline, avoid web lookup, or use another named tool.
+${END_MARKER}`;
+
+export const CLI_ROUTER_CARD_SHA256 =
+  'f781e09b71c0d7f5a60f5bbf37a0c656cf30ade2876212a5f0dcde6bebaad995';
+
+export type RouterCardVariant = 'full-bundle-v1' | 'cli-v1';
+
+interface RouterCardPayload {
+  content: string;
+  version: number;
+  sha256: string;
+}
+
 function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
 if (
   sha256(ROUTER_CARD) !== ROUTER_CARD_SHA256 ||
+  sha256(CLI_ROUTER_CARD) !== CLI_ROUTER_CARD_SHA256 ||
   sha256(ROUTER_SKILL_DESCRIPTION_PREFIX) !==
     ROUTER_SKILL_DESCRIPTION_PREFIX_SHA256
 ) {
-  throw new Error('Firecrawl router guidance no longer matches EXP-028.');
+  throw new Error(
+    'Firecrawl router guidance no longer matches its pinned experiment payload.'
+  );
+}
+
+function routerCardPayload(variant: RouterCardVariant): RouterCardPayload {
+  if (variant === 'cli-v1') {
+    return {
+      content: CLI_ROUTER_CARD,
+      version: CLI_ROUTER_CARD_VERSION,
+      sha256: CLI_ROUTER_CARD_SHA256,
+    };
+  }
+  return {
+    content: ROUTER_CARD,
+    version: ROUTER_CARD_VERSION,
+    sha256: ROUTER_CARD_SHA256,
+  };
 }
 
 export type RouterCardAgent = 'claude' | 'codex';
@@ -182,7 +226,7 @@ function validateMarkers(content: string): { start: number; end: number } {
   };
 }
 
-function updateManagedBlock(existing: string): string {
+function updateManagedBlock(existing: string, card: string): string {
   const markers = validateMarkers(existing);
   if (markers.start >= 0) {
     if (markers.end < markers.start) {
@@ -190,18 +234,18 @@ function updateManagedBlock(existing: string): string {
         'Refusing to update malformed or duplicate Firecrawl router-card markers.'
       );
     }
-    return `${existing.slice(0, markers.start)}${ROUTER_CARD}${existing.slice(
+    return `${existing.slice(0, markers.start)}${card}${existing.slice(
       markers.end + END_MARKER.length
     )}`;
   }
 
-  if (!existing) return `${ROUTER_CARD}\n`;
+  if (!existing) return `${card}\n`;
   const separator = existing.endsWith('\n\n')
     ? ''
     : existing.endsWith('\n')
       ? '\n'
       : '\n\n';
-  return `${existing}${separator}${ROUTER_CARD}\n`;
+  return `${existing}${separator}${card}\n`;
 }
 
 function removeManagedBlock(existing: string): string {
@@ -246,21 +290,23 @@ export function atomicWriteFile(
 
 export function installRouterCard(
   agent: RouterCardAgent,
-  projectPath: string
+  projectPath: string,
+  variant: RouterCardVariant = 'full-bundle-v1'
 ): RouterCardResult {
+  const payload = routerCardPayload(variant);
   const project = path.resolve(projectPath);
   const destination = routerCardPath(project, resolveRouterCardContext(agent));
   assertSafeProjectPath(project, destination);
 
   const exists = existsSync(destination);
   const existing = exists ? readFileSync(destination, 'utf8') : '';
-  const updated = updateManagedBlock(existing);
+  const updated = updateManagedBlock(existing, payload.content);
   if (updated === existing) {
     return {
       path: destination,
       changed: false,
-      version: ROUTER_CARD_VERSION,
-      sha256: ROUTER_CARD_SHA256,
+      version: payload.version,
+      sha256: payload.sha256,
     };
   }
 
@@ -269,9 +315,16 @@ export function installRouterCard(
   return {
     path: destination,
     changed: true,
-    version: ROUTER_CARD_VERSION,
-    sha256: ROUTER_CARD_SHA256,
+    version: payload.version,
+    sha256: payload.sha256,
   };
+}
+
+export function installCliRouterCard(
+  agent: RouterCardAgent,
+  projectPath: string
+): RouterCardResult {
+  return installRouterCard(agent, projectPath, 'cli-v1');
 }
 
 /** Validate ownership and path safety before a multi-artifact state change. */


### PR DESCRIPTION
## Summary
- add the project-local CLI-capability router card used by the powered P2 study
- install it by default when `firecrawl init` completes an eligible project state: authenticated CLI, installed skills, explicit Claude/Codex agent, and explicit project path
- provide `--no-router-card` as a per-run opt-out and `--remove-router-card` as a bounded removal command
- preserve existing user context through a delimited, idempotent managed block

## Exact journey

Default-on eligible setup:

```bash
firecrawl init --yes --agent claude --project /path/to/project
# or
firecrawl init --yes --agent codex --project /path/to/project
```

This writes only the project-local native context file (`CLAUDE.md` for Claude, `AGENTS.md` for Codex). It does not write a global instruction file.

Opt out for one run:

```bash
firecrawl init --yes --agent claude --project /path/to/project --no-router-card
```

Remove only the managed block without rerunning onboarding:

```bash
firecrawl init --agent claude --project /path/to/project --remove-router-card
```

Package installation alone, login/logout, unsupported agents, missing authentication, skipped skills, and commands without an explicit project do not write a card.

## Decision-grade evidence
P2 ran 384 immutable Convex-backed traces across Claude Sonnet 5 and Codex Terra at 30-way E2B concurrency.

- card with native web available: 50% → 100%, +50pp pooled, Holm-adjusted p ≈ 0.000003
- Claude: 0% → 100%, +100pp; Codex: 100% → 100%, ceiling/null
- safety: 0/96 treatment-only regressions; simultaneous upper bound 4.18%, passes the preregistered <5% gate
- native-web suppression was independently rejected: 21/96 regressions and no incremental benefit once the card was present

**Recommendation:** ship this project-local card for the CLI + skills state and leave native web tools available. The result transfers by machine-state equivalence, not by command-name similarity.

Aggregate decision artifact: Convex `kg2e1vb0xg4k95v70wb2ahzn018arvnv`. Raw traces and receipts are not stored in Git.

## Scope
This draft does not write global `CLAUDE.md`/`AGENTS.md`, mutate project files during package install or login/logout, or suppress native web tools. Additional onboarding aliases should adopt the card only after a small state-parity canary.

## Verification
- `pnpm test` (401 passed)
- `pnpm run build`
- `git diff --check`
- GitHub checks run on Ubuntu, macOS, and Windows
