### PR TITLE
feat(search): add highlights option

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ firecrawl search "AI data tools"
 | `--location <location>`      | Geo-targeting (e.g., "Germany", "San Francisco,California,United States")                   |
 | `--country <code>`           | ISO country code (default: US)                                                              |
 | `--timeout <ms>`             | Timeout in milliseconds (default: 60000)                                                    |
+| `--highlights`               | Return query-relevant highlights for each result                                            |
+| `--no-highlights`            | Keep the original search snippets                                                           |
 | `--ignore-invalid-urls`      | Exclude URLs invalid for other Firecrawl endpoints                                          |
 | `--scrape`                   | Enable scraping of search results                                                           |
 | `--scrape-formats <formats>` | Scrape formats when `--scrape` enabled (default: markdown)                                  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.19.26",
+  "version": "1.19.27",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/commands/search.test.ts
+++ b/src/__tests__/commands/search.test.ts
@@ -84,6 +84,23 @@ describe('executeSearch', () => {
       });
     });
 
+    it('should allow highlights to be disabled', async () => {
+      mockHttpPost.mockResolvedValue(mockSearchResponse({ web: [] }));
+
+      await executeSearch({
+        query: 'test query',
+        highlights: false,
+      });
+
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/v2/search',
+        expect.objectContaining({
+          highlights: false,
+          query: 'test query',
+        })
+      );
+    });
+
     it('should pass apiUrl to getClient when provided', async () => {
       mockHttpPost.mockResolvedValue(mockSearchResponse({ web: [] }));
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -27,6 +27,10 @@ export async function executeSearch(
       integration: 'cli',
     };
 
+    if (options.highlights !== undefined) {
+      searchParams.highlights = options.highlights;
+    }
+
     // Add sources if specified
     if (options.sources && options.sources.length > 0) {
       searchParams.sources = options.sources.map((source) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -943,6 +943,14 @@ function createSearchCommand(): Command {
       'Exclude URLs invalid for other Firecrawl endpoints',
       false
     )
+    .option(
+      '--highlights',
+      'Return query-relevant highlights for each search result'
+    )
+    .option(
+      '--no-highlights',
+      'Keep the original search snippets instead of returning highlights'
+    )
     .option('--scrape', 'Enable scraping of search results', false)
     .option(
       '--scrape-formats <formats>',
@@ -1022,6 +1030,7 @@ function createSearchCommand(): Command {
         country: options.country,
         timeout: options.timeout,
         ignoreInvalidUrls: options.ignoreInvalidUrls,
+        highlights: options.highlights,
         scrape: options.scrape,
         scrapeFormats,
         onlyMainContent: options.onlyMainContent,

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -30,6 +30,8 @@ export interface SearchOptions {
   timeout?: number;
   /** Exclude URLs invalid for other Firecrawl endpoints */
   ignoreInvalidUrls?: boolean;
+  /** Return query-relevant highlights instead of the original search snippets */
+  highlights?: boolean;
   /** Output file path */
   output?: string;
   /** Output as JSON format */


### PR DESCRIPTION
## Summary

- add `--highlights` and `--no-highlights` search options
- forward the field only when the user explicitly selects either option
- document the options and bump the package version to `1.19.27`

## Validation

- `pnpm run type-check`
- `pnpm exec vitest run src/__tests__/commands/search.test.ts`
- `pnpm exec prettier --check src/index.ts src/types/search.ts src/commands/search.ts src/__tests__/commands/search.test.ts README.md package.json`
