### PR TITLE
docs(skills): document --highlights flag in firecrawl-search

### DIFF
--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -42,11 +42,13 @@ firecrawl search "your query" --sources news --tbs qdr:d -o .firecrawl/news.json
 | `--country <code>`                   | Country code for search                       |
 | `--scrape`                           | Also scrape full page content for each result |
 | `--scrape-formats`                   | Formats when scraping (default: markdown)     |
+| `--highlights` / `--no-highlights`   | Query-relevant excerpts vs. original snippets |
 | `-o, --output <path>`                | Output file path                              |
 | `--json`                             | Output as JSON                                |
 
 ## Tips
 
+- **`--highlights` is on by default.** Firecrawl's relevance model scores every paragraph/list/table on the page against your query and returns only the excerpts that answer it, instead of full-page noise. Use `--no-highlights` to get the original snippets. This is a server-side upgrade (works with or without the flag), but the flag lets you control it explicitly.
 - **`--scrape` fetches full content** — don't re-scrape URLs from search results. This saves credits and avoids redundant fetches.
 - Always write results to `.firecrawl/` with `-o` to avoid context window bloat.
 - Use `jq` to extract URLs or titles: `jq -r '.data.web[].url' .firecrawl/search.json`

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -75,7 +75,7 @@ Each result holds `id`, `type` (`issue`, `pull_request`, `readme`, `doc`),
 
 ## Tips
 
-- **`--highlights` is on by default:** results are query-relevant excerpts, not full-page snippets. Use `--no-highlights` for the original snippets.
+- **`--highlights` on by default:** results are query-relevant excerpts, not full-page snippets. Use `--no-highlights` for the original snippets.
 - **`--scrape` fetches full content** — don't re-scrape URLs from search results. This saves credits and avoids redundant fetches.
 - Always write results to `.firecrawl/` with `-o` to avoid context window bloat.
 - Use `jq` to extract URLs or titles: `jq -r '.data.web[].url' .firecrawl/search.json`

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -75,7 +75,7 @@ Each result holds `id`, `type` (`issue`, `pull_request`, `readme`, `doc`),
 
 ## Tips
 
-- **`--highlights` is on by default.** Firecrawl's relevance model scores every paragraph/list/table on the page against your query and returns only the excerpts that answer it, instead of full-page noise. Use `--no-highlights` to get the original snippets. This is a server-side upgrade (works with or without the flag), but the flag lets you control it explicitly.
+- **`--highlights` is on by default:** results are query-relevant excerpts, not full-page snippets. Use `--no-highlights` for the original snippets.
 - **`--scrape` fetches full content** — don't re-scrape URLs from search results. This saves credits and avoids redundant fetches.
 - Always write results to `.firecrawl/` with `-o` to avoid context window bloat.
 - Use `jq` to extract URLs or titles: `jq -r '.data.web[].url' .firecrawl/search.json`


### PR DESCRIPTION
## Summary
- `firecrawl search --help` already exposes `--highlights` / `--no-highlights` (added alongside the new relevance-model search excerpts), but the `firecrawl-search` skill doc never documented them.
- Adds the flags to the options table and a tip explaining that highlights are on by default and backed by the server-side relevance model described in https://www.firecrawl.dev/blog/introducing-our-most-accurate-search-yet.

## Test plan
- [x] Confirmed via `firecrawl search --help` on CLI 1.19.27 that both flags exist and match the doc wording.
- [ ] Docs render correctly in skill viewers (markdown table + list only, no other change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/cli/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787483630&installation_model_id=11126&pr_number=166&repository=firecrawl%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fcli%2Fpull%2F166&signature=c83c96e3423d17a65e2b91598fc4c86c072d2c5a167cf0183d8d8afab6594cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->