### PR TITLE
fix(cli): harden init MCP installer

### DIFF
--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -2,13 +2,38 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execSync } from 'child_process';
 import { handleInitCommand } from '../../commands/init';
 
+const { installMcpMock, getApiKeyMock, confirmMock, checkboxMock } = vi.hoisted(
+  () => ({
+    installMcpMock: vi.fn(),
+    getApiKeyMock: vi.fn(),
+    confirmMock: vi.fn(),
+    checkboxMock: vi.fn(),
+  })
+);
+
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
+}));
+
+vi.mock('../../commands/setup', () => ({
+  installMcp: installMcpMock,
+}));
+
+vi.mock('../../utils/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/config')>()),
+  getApiKey: getApiKeyMock,
+}));
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: confirmMock,
+  checkbox: checkboxMock,
+  select: vi.fn(),
 }));
 
 describe('handleInitCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getApiKeyMock.mockReturnValue(undefined);
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -57,6 +82,55 @@ describe('handleInitCommand', () => {
     expect(execSync).toHaveBeenCalledWith(
       'npx -y skills add firecrawl/firecrawl-workflows --full-depth --global --yes --agent cursor',
       expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  });
+
+  it('routes interactive MCP setup through the hardened hosted installer', async () => {
+    getApiKeyMock.mockReturnValue('fc-stored-key');
+    confirmMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    checkboxMock.mockResolvedValueOnce(['mcp']);
+    installMcpMock.mockResolvedValueOnce(undefined);
+
+    await handleInitCommand({
+      skipInstall: true,
+      skipAuth: true,
+      global: true,
+      agent: 'codex',
+    });
+
+    expect(installMcpMock).toHaveBeenCalledWith({
+      global: true,
+      agent: 'codex',
+      yes: true,
+      quiet: true,
+    });
+    expect(execSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('add-mcp'),
+      expect.anything()
+    );
+  });
+
+  it('does not print installer errors that could contain a stored credential', async () => {
+    getApiKeyMock.mockReturnValue('fc-stored-key');
+    confirmMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    checkboxMock.mockResolvedValueOnce(['mcp']);
+    installMcpMock.mockRejectedValueOnce(
+      new Error('installer failed for fc-stored-key')
+    );
+
+    await handleInitCommand({ skipInstall: true, skipAuth: true });
+
+    expect(console.error).toHaveBeenCalledWith(
+      '  Failed to install MCP securely. Run "firecrawl setup mcp" later.'
+    );
+    expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
+      'fc-stored-key'
     );
   });
 });

--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -106,6 +106,7 @@ describe('handleInitCommand', () => {
       agent: 'codex',
       yes: true,
       quiet: true,
+      keyless: true,
     });
     expect(execSync).not.toHaveBeenCalledWith(
       expect.stringContaining('add-mcp'),
@@ -127,7 +128,7 @@ describe('handleInitCommand', () => {
     await handleInitCommand({ skipInstall: true, skipAuth: true });
 
     expect(console.error).toHaveBeenCalledWith(
-      '  Failed to install MCP securely. Run "firecrawl setup mcp" later.'
+      '  Failed to install MCP securely: installer failed for [REDACTED]'
     );
     expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
       'fc-stored-key'

--- a/src/__tests__/commands/setup.test.ts
+++ b/src/__tests__/commands/setup.test.ts
@@ -14,6 +14,7 @@ import path from 'path';
 import {
   handleMakeDefaultCommand,
   handleSetupCommand,
+  installMcp,
   installHermesMcp,
   installOpenClawMcp,
   installSkillsForAgent,
@@ -204,6 +205,35 @@ describe('handleSetupCommand', () => {
       })
     ).rejects.toThrow('Export FIRECRAWL_API_KEY');
     expect(execFileSync).not.toHaveBeenCalled();
+  });
+  it('can explicitly install keyless MCP without exposing a stored API key', async () => {
+    await installMcp({
+      agent: 'claude-code',
+      global: true,
+      yes: true,
+      keyless: true,
+    });
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      'npx',
+      [
+        '-y',
+        'add-mcp@1.14.0',
+        'https://mcp.firecrawl.dev/v2/mcp',
+        '--name',
+        'firecrawl',
+        '--transport',
+        'http',
+        '--global',
+        '--agent',
+        'claude-code',
+        '--yes',
+      ],
+      expect.objectContaining({ stdio: 'inherit' })
+    );
+    expect(vi.mocked(execFileSync).mock.calls.flat().join(' ')).not.toContain(
+      'fc-test-key'
+    );
   });
   it('normalizes launch aliases for environment-backed MCP setup', async () => {
     process.env.FIRECRAWL_API_KEY = 'fc-test-key';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -25,6 +25,7 @@ import {
   WEB_AGENTS,
   type WebAgent,
 } from '../utils/web-defaults';
+import { installMcp } from './setup';
 
 export interface InitOptions {
   global?: boolean;
@@ -606,25 +607,17 @@ async function stepIntegrations(options: InitOptions): Promise<number | null> {
           );
           break;
         }
-        const args = [
-          'npx',
-          '-y',
-          'add-mcp',
-          '"npx -y firecrawl-mcp"',
-          '--name',
-          'firecrawl',
-        ];
-        if (options.global) args.push('--global');
-        if (options.agent) args.push('--agent', options.agent);
         try {
-          execSync(args.join(' '), {
-            stdio: 'inherit',
-            env: { ...cleanNpmEnv(), FIRECRAWL_API_KEY: apiKey },
+          await installMcp({
+            global: options.global,
+            agent: options.agent,
+            yes: true,
+            quiet: true,
           });
           console.log(`  ${green}✓${reset} MCP server installed`);
         } catch {
           console.error(
-            '  Failed to install MCP. Run "firecrawl setup mcp" later.'
+            '  Failed to install MCP securely. Run "firecrawl setup mcp" later.'
           );
         }
         break;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -601,24 +601,29 @@ async function stepIntegrations(options: InitOptions): Promise<number | null> {
       case 'mcp': {
         console.log(`\n  Setting up MCP server...`);
         const apiKey = getApiKey();
-        if (!apiKey) {
-          console.log(
-            `  ${dim}Skipped — no API key found. Run "firecrawl login" first, then "firecrawl setup mcp".${reset}`
-          );
-          break;
-        }
+        const environmentBacked = Boolean(
+          apiKey && process.env.FIRECRAWL_API_KEY === apiKey
+        );
         try {
           await installMcp({
             global: options.global,
-            agent: options.agent,
+            agent: options.agent ?? (environmentBacked ? 'all' : undefined),
             yes: true,
             quiet: true,
+            // Stored credentials must never be persisted into MCP client config.
+            // Install the anonymous endpoint instead; an environment-backed
+            // credential continues through the authenticated setup path.
+            keyless: !environmentBacked,
           });
           console.log(`  ${green}✓${reset} MCP server installed`);
-        } catch {
-          console.error(
-            '  Failed to install MCP securely. Run "firecrawl setup mcp" later.'
-          );
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? apiKey
+                ? error.message.replaceAll(apiKey, '[REDACTED]')
+                : error.message
+              : 'unknown error';
+          console.error(`  Failed to install MCP securely: ${message}`);
         }
         break;
       }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -51,6 +51,8 @@ export interface SetupOptions {
   nativeSkills?: boolean;
   /** Render compact skill install output. */
   quiet?: boolean;
+  /** Configure the anonymous hosted MCP path even when a stored key exists. */
+  keyless?: boolean;
 }
 
 const green = '\x1b[32m';
@@ -185,7 +187,7 @@ function isEnvironmentBackedApiKey(apiKey: string | undefined): boolean {
   return Boolean(apiKey && process.env[ENV_API_KEY] === apiKey);
 }
 
-function assertSubprocessSafeCredential(apiKey = getApiKey()): void {
+function assertSubprocessSafeCredential(apiKey?: string): void {
   if (apiKey && !isEnvironmentBackedApiKey(apiKey)) {
     throw new Error(
       'Secure MCP setup cannot pass a stored API key to this client. Export FIRECRAWL_API_KEY and rerun with a supported --agent, or run keyless setup without a credential.'
@@ -210,9 +212,9 @@ function environmentHeaderForAgent(agent?: string): string | undefined {
 }
 
 function firecrawlMcpHeaders(
-  agent?: string
+  agent?: string,
+  apiKey?: string
 ): Record<string, string> | undefined {
-  const apiKey = getApiKey();
   if (!apiKey) return undefined;
 
   // Keep this helper safe in isolation. Callers currently reject stored keys
@@ -527,7 +529,7 @@ export async function installMcp(options: SetupOptions): Promise<void> {
     throw new Error('Choose either --global or --project, not both.');
   }
 
-  const apiKey = getApiKey();
+  const apiKey = options.keyless ? undefined : getApiKey();
   const resolvedAgent = resolveMcpAgent(options.agent);
   if (resolvedAgent.kind === 'all-launchers' && options.project && apiKey) {
     throw new Error(
@@ -569,7 +571,7 @@ async function installAddMcp(
   resolvedAgent: Extract<ResolvedMcpAgent, { kind: 'add-mcp' }>
 ): Promise<void> {
   const mcpUrl = firecrawlHostedMcpUrl();
-  const apiKey = getApiKey();
+  const apiKey = options.keyless ? undefined : getApiKey();
   if (
     resolvedAgent.agent === 'codex' &&
     !options.project &&
@@ -580,7 +582,7 @@ async function installAddMcp(
     return;
   }
 
-  const headers = firecrawlMcpHeaders(resolvedAgent.agent);
+  const headers = firecrawlMcpHeaders(resolvedAgent.agent, apiKey);
   const useGlobal = !options.project && Boolean(options.global);
 
   const args = [
@@ -670,7 +672,7 @@ function firecrawlMcpConfig(agent?: string): {
 } {
   return {
     url: firecrawlHostedMcpUrl(),
-    headers: firecrawlMcpHeaders(agent),
+    headers: firecrawlMcpHeaders(agent, getApiKey()),
   };
 }
 


### PR DESCRIPTION
## Summary
- route interactive `firecrawl init` MCP setup through the pinned hosted installer
- remove the unpinned `add-mcp` / `firecrawl-mcp` subprocess path and stored-key child environment
- add init regression coverage for secure delegation and sanitized failures

## Contract
- unattended/keyless setup remains on `https://mcp.firecrawl.dev/v2/mcp`
- no OAuth endpoint change

## Validation
- `pnpm exec vitest run src/__tests__/commands/init.test.ts`
- `pnpm test` (389 passed, 1 skipped)
- `pnpm run type-check`
- `pnpm run format:check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/cli/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787727091&installation_model_id=11126&pr_number=167&repository=firecrawl%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fcli%2Fpull%2F167&signature=0c33e484c844afc5a1b0ff30f7cc5ad54a715520c4c9028352a2d50a19d43263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `firecrawl init` MCP setup and kept it usable without exposing keys. Interactive flow now delegates to the pinned hosted installer with a keyless fallback and redacted error messages.

- **Bug Fixes**
  - Interactive MCP setup now uses the hosted `installMcp` (pinned) with `keyless` when no environment-backed key is present; no more skipped install.
  - Removed the direct `add-mcp`/`firecrawl-mcp` subprocess and the child env that carried `FIRECRAWL_API_KEY`.
  - Added tests to enforce secure delegation, keyless installs to https://mcp.firecrawl.dev/v2/mcp, and credential redaction in errors.

<sup>Written for commit c28d8ed0a495bace96655b6dc3d8176622025f2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

