### PR TITLE
docs(cli): state scrape defaults in help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,7 +343,7 @@ program
 function createScrapeCommand(): Command {
   const scrapeCmd = new Command('scrape')
     .description(
-      'Scrape one or more URLs. Multiple URLs are scraped concurrently and saved to .firecrawl/'
+      'Scrape one or more URLs. A single URL prints to stdout by default. Multiple URLs are scraped concurrently and saved to .firecrawl/'
     )
     .argument('[urls...]', 'URL(s) to scrape')
     .option(
@@ -353,7 +353,7 @@ function createScrapeCommand(): Command {
     .option('-H, --html', 'Output raw HTML (shortcut for --format html)')
     .option(
       '-f, --format <formats>',
-      'Output format(s). Multiple formats can be specified with commas (e.g., "markdown,links,images"). Available: markdown, html, rawHtml, links, images, screenshot, summary, changeTracking, json, attributes, branding. Single format outputs raw content; multiple formats output JSON.'
+      'Output format(s) (default: markdown). Multiple formats can be specified with commas (e.g., "markdown,links,images"). Available: markdown, html, rawHtml, links, images, screenshot, summary, changeTracking, json, attributes, branding. Single format outputs raw content; multiple formats output JSON.'
     )
     .option('--only-main-content', 'Include only main content', false)
     .option(
@@ -371,7 +371,10 @@ function createScrapeCommand(): Command {
       'Firecrawl API key (overrides global --api-key)'
     )
     .option('--api-url <url>', 'API URL (overrides global --api-url)')
-    .option('-o, --output <path>', 'Output file path (default: stdout)')
+    .option(
+      '-o, --output <path>',
+      'Output file path for a single URL (default: stdout)'
+    )
     .option('--json', 'Output as JSON format', false)
     .option('--pretty', 'Pretty print JSON output', false)
     .option(


### PR DESCRIPTION
## Why

`firecrawl scrape` is the command that downloads a web page. Its help text leaves out three facts a first-time user needs.

Here is the current help, and what each line does not say:

```text
Scrape one or more URLs. Multiple URLs are scraped concurrently and saved to .firecrawl/
```
This describes what many URLs do. It never says what one URL does: the page prints to stdout. A user who scrapes one page and expects a file gets nothing on disk and no explanation.

```text
-o, --output <path>  Output file path (default: stdout)
```
This says where one URL goes. It never says the flag only applies to a single URL.

```text
-f, --format <formats>  Output format(s). Multiple formats can be specified with commas ...
```
This lists eleven formats. It never states which one you get by default: markdown.

## Summary

The same three lines, after:

```text
Scrape one or more URLs. A single URL prints to stdout by default. Multiple URLs are scraped concurrently and saved to .firecrawl/
```

```text
-o, --output <path>  Output file path for a single URL (default: stdout)
```

```text
-f, --format <formats>  Output format(s) (default: markdown). Multiple formats can be specified with commas ...
```

## Test Plan

- `pnpm run build` succeeds and `pnpm run format:check` passes on this exact commit.
- Each added statement was checked against live behavior: one URL writes to stdout, multiple URLs save under `.firecrawl/`, and a bare scrape returns markdown.
- We ran four AI coding agents in clean containers, once against the current CLI and once against this exact commit, every session on the identical prompt: "hey can you use the firecrawl cli to save the page at https://bun.com/docs as a markdown file?" All eight runs saved the file. Against the current CLI, all four agents ran `scrape --help` before their first scrape. With this commit, two of the four went straight to a correct scrape without it. All eight sessions and the comparison: [full transcripts](https://gist.github.com/sshkeda/dc911ef7d68bbd68476649394c2b9132).
