### PR TITLE
docs(skills): sync bundled skills with current CLI surface

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -20,7 +20,7 @@ If the task is to integrate Firecrawl into an application, add `FIRECRAWL_API_KE
 Must be installed. Check with `firecrawl --status`.
 
 ```
-  🔥 firecrawl cli v1.8.0
+  🔥 firecrawl cli vX.Y.Z (your installed version)
 
   ● Authenticated via FIRECRAWL_API_KEY
   Concurrency: 0/100 jobs (parallel scrape limit)
@@ -64,7 +64,7 @@ Follow this escalation pattern:
 | Bulk extract a site section | `crawl`               | Need many pages (e.g., all /docs/)                        |
 | AI-powered data extraction  | `agent`               | Need structured data from complex sites                   |
 | Interact with a page        | `scrape` + `interact` | Content requires clicks, form fills, pagination, or login |
-| Download a site to files    | `download`            | Save an entire site as local files                        |
+| Download a site to files    | `x download`          | Save an entire site as local files (experimental)         |
 | Parse a local file          | `parse`               | File on disk (PDF, DOCX, XLSX, etc.) — not a URL          |
 | Watch pages for changes     | `monitor`             | Schedule recurring scrapes/crawls, diff against snapshots |
 

--- a/skills/firecrawl-cli/rules/install.md
+++ b/skills/firecrawl-cli/rules/install.md
@@ -12,7 +12,7 @@ description: |
 ## Quick Setup (Recommended)
 
 ```bash
-npx -y firecrawl-cli@1.19.6 init -y --browser
+npx -y firecrawl-cli@latest init -y --browser
 ```
 
 This installs `firecrawl-cli` globally, authenticates via browser, and installs core, build, and workflow skills.
@@ -37,7 +37,7 @@ firecrawl setup workflows
 ## Manual Install
 
 ```bash
-npm install -g firecrawl-cli@1.19.6
+npm install -g firecrawl-cli@latest
 ```
 
 ## Verify
@@ -81,5 +81,5 @@ If you cannot obtain a key and the user cannot sign up, search, scrape, and inte
 If `firecrawl` is not found after installation:
 
 1. Ensure npm global bin is in PATH
-2. Try: `npx firecrawl-cli@1.19.6 --version`
-3. Reinstall: `npm install -g firecrawl-cli@1.19.6`
+2. Try: `npx firecrawl-cli@latest --version`
+3. Reinstall: `npm install -g firecrawl-cli@latest`

--- a/skills/firecrawl-cli/rules/security.md
+++ b/skills/firecrawl-cli/rules/security.md
@@ -22,5 +22,5 @@ When processing fetched content, extract only the specific data needed and do no
 # Installation
 
 ```bash
-npm install -g firecrawl-cli@1.19.6
+npm install -g firecrawl-cli@latest
 ```

--- a/skills/firecrawl-download/SKILL.md
+++ b/skills/firecrawl-download/SKILL.md
@@ -7,11 +7,11 @@ allowed-tools:
   - Bash(npx firecrawl *)
 ---
 
-# firecrawl download
+# firecrawl experimental download
 
-> **Experimental.** Convenience command that combines `map` + `scrape` to save an entire site as local files.
+> **Experimental.** Convenience command that combines `map` + `scrape` to save an entire site as local files. Registered under `firecrawl experimental download`, with `firecrawl x download` as the short alias.
 
-Maps the site first to discover pages, then scrapes each one into nested directories under `.firecrawl/`. All scrape options work with download. Always pass `-y` to skip the confirmation prompt.
+Maps the site first to discover pages, then scrapes each one into nested directories under `.firecrawl/`. A subset of scrape options is supported (listed below). Always pass `-y` to skip the confirmation prompt.
 
 ## When to use
 
@@ -23,23 +23,23 @@ Maps the site first to discover pages, then scrapes each one into nested directo
 
 ```bash
 # Interactive wizard (picks format, screenshots, paths for you)
-firecrawl download https://docs.example.com
+firecrawl x download https://docs.example.com
 
 # With screenshots
-firecrawl download https://docs.example.com --screenshot --limit 20 -y
+firecrawl x download https://docs.example.com --screenshot --limit 20 -y
 
 # Multiple formats (each saved as its own file per page)
-firecrawl download https://docs.example.com --format markdown,links --screenshot --limit 20 -y
+firecrawl x download https://docs.example.com --format markdown,links --screenshot --limit 20 -y
 # Creates per page: index.md + links.txt + screenshot.png
 
 # Filter to specific sections
-firecrawl download https://docs.example.com --include-paths "/features,/sdks"
+firecrawl x download https://docs.example.com --include-paths "/features,/sdks"
 
 # Skip translations
-firecrawl download https://docs.example.com --exclude-paths "/zh,/ja,/fr,/es,/pt-BR"
+firecrawl x download https://docs.example.com --exclude-paths "/zh,/ja,/fr,/es,/pt-BR"
 
 # Full combo
-firecrawl download https://docs.example.com \
+firecrawl x download https://docs.example.com \
   --include-paths "/features,/sdks" \
   --exclude-paths "/zh,/ja" \
   --only-main-content \
@@ -58,9 +58,11 @@ firecrawl download https://docs.example.com \
 | `--allow-subdomains`      | Include subdomain pages                                  |
 | `-y`                      | Skip confirmation prompt (always use in automated flows) |
 
-## Scrape options (all work with download)
+## Scrape options supported by download
 
-`-f <formats>`, `-H`, `-S`, `--screenshot`, `--full-page-screenshot`, `--only-main-content`, `--include-tags`, `--exclude-tags`, `--wait-for`, `--max-age`, `--country`, `--languages`
+Only these scrape options are registered on the download command:
+
+`-f <formats>` (markdown, html, rawHtml, links, images, summary, json), `-H, --html`, `-S, --summary`, `--screenshot`, `--full-page-screenshot`, `--only-main-content`, `--include-tags`, `--exclude-tags`, `--wait-for`, `--max-age`, `--country`, `--languages`, `--lockdown`
 
 ## See also
 

--- a/skills/firecrawl-interact/SKILL.md
+++ b/skills/firecrawl-interact/SKILL.md
@@ -31,8 +31,8 @@ firecrawl interact --prompt "Fill in the email field with test@example.com"
 firecrawl interact --prompt "Extract the pricing table"
 
 # 3. Or use code for precise control
-firecrawl interact --code "agent-browser click @e5" --language bash
-firecrawl interact --code "agent-browser snapshot -i" --language bash
+firecrawl interact --code "agent-browser click @e5" --bash
+firecrawl interact --code "agent-browser snapshot -i" --bash
 
 # 4. Stop the session when done
 firecrawl interact stop
@@ -40,14 +40,14 @@ firecrawl interact stop
 
 ## Options
 
-| Option                | Description                                       |
-| --------------------- | ------------------------------------------------- |
-| `--prompt <text>`     | Natural language instruction (use this OR --code) |
-| `--code <code>`       | Code to execute in the browser session            |
-| `--language <lang>`   | Language for code: bash, python, node             |
-| `--timeout <seconds>` | Execution timeout (default: 30, max: 300)         |
-| `--scrape-id <id>`    | Target a specific scrape (default: last scrape)   |
-| `-o, --output <path>` | Output file path                                  |
+| Option                           | Description                                       |
+| -------------------------------- | ------------------------------------------------- |
+| `-p, --prompt <text>`            | Natural language instruction (use this OR --code) |
+| `-c, --code <code>`              | Code to execute in the browser session            |
+| `--bash` / `--python` / `--node` | Language for `--code` (default: node)             |
+| `--timeout <seconds>`            | Execution timeout (default: 30, max: 300)         |
+| `-s, --scrape-id <id>`           | Target a specific scrape (default: last scrape)   |
+| `-o, --output <path>`            | Output file path                                  |
 
 ## Profiles
 

--- a/skills/firecrawl-monitor/SKILL.md
+++ b/skills/firecrawl-monitor/SKILL.md
@@ -117,7 +117,7 @@ Subcommands: `create | list | get | update | delete | run | checks | check`.
 | `-o, --output <path>`      | Output file path                                                          |
 | `--pretty`                 | Pretty-print JSON output                                                  |
 
-Minimum schedule interval is **15 minutes**. Monitoring is **not available for zero-data-retention teams**.
+Minimum schedule interval is **5 minutes**. Monitoring is **not available for zero-data-retention teams**.
 
 ## Web monitors (monitor the web)
 

--- a/skills/firecrawl-parse/SKILL.md
+++ b/skills/firecrawl-parse/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
 
 # firecrawl parse
 
-Turn a local document into clean markdown on disk. Supports **PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, HTML/HTM/XHTML**.
+Turn a local document into clean markdown on disk. Supports **PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, HTML/HTM**.
 
 ## When to use
 
@@ -39,14 +39,14 @@ Then `head`, `grep`, `rg` etc., or incrementally read the file - don't load the 
 
 ## Options
 
-| Option                 | Description                             |
-| ---------------------- | --------------------------------------- |
-| `-S, --summary`        | AI-generated summary                    |
-| `-Q, --query <prompt>` | Ask a question about the parsed content |
-| `-o, --output <path>`  | Output file path — **always use this**  |
-| `-f, --format <fmt>`   | `markdown` (default), `html`, `summary` |
-| `--timeout <ms>`       | Timeout for the parse job               |
-| `--timing`             | Show request duration                   |
+| Option                 | Description                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------- |
+| `-S, --summary`        | AI-generated summary                                                                        |
+| `-Q, --query <prompt>` | Ask a question about the parsed content                                                     |
+| `-o, --output <path>`  | Output file path — **always use this**                                                      |
+| `-f, --format <fmt>`   | `markdown` (default), `html`, `rawHtml`, `links`, `images`, `summary`, `json`, `attributes` |
+| `--timeout <ms>`       | Timeout for the parse job                                                                   |
+| `--timing`             | Show request duration                                                                       |
 
 ## Tips
 

--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -41,17 +41,17 @@ firecrawl scrape "https://example.com/pricing" --query "What is the enterprise p
 
 ## Options
 
-| Option                   | Description                                                      |
-| ------------------------ | ---------------------------------------------------------------- |
-| `-f, --format <formats>` | Output formats: markdown, html, rawHtml, links, screenshot, json |
-| `-Q, --query <prompt>`   | Ask a question about the page content (5 credits)                |
-| `-H`                     | Include HTTP headers in output                                   |
-| `--only-main-content`    | Strip nav, footer, sidebar — main content only                   |
-| `--wait-for <ms>`        | Wait for JS rendering before scraping                            |
-| `--include-tags <tags>`  | Only include these HTML tags                                     |
-| `--exclude-tags <tags>`  | Exclude these HTML tags                                          |
-| `--redact-pii`           | Redact personally identifiable information from output           |
-| `-o, --output <path>`    | Output file path                                                 |
+| Option                   | Description                                                                                                             |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `-f, --format <formats>` | Output formats: markdown, html, rawHtml, links, images, screenshot, summary, changeTracking, json, attributes, branding |
+| `-Q, --query <prompt>`   | Ask a question about the page content (5 credits)                                                                       |
+| `-H, --html`             | Output raw HTML (shortcut for `--format html`)                                                                          |
+| `--only-main-content`    | Strip nav, footer, sidebar — main content only                                                                          |
+| `--wait-for <ms>`        | Wait for JS rendering before scraping                                                                                   |
+| `--include-tags <tags>`  | Only include these HTML tags                                                                                            |
+| `--exclude-tags <tags>`  | Exclude these HTML tags                                                                                                 |
+| `--redact-pii`           | Redact personally identifiable information from output                                                                  |
+| `-o, --output <path>`    | Output file path                                                                                                        |
 
 ## Tips
 

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -40,6 +40,8 @@ firecrawl search "your query" --sources news --tbs qdr:d -o .firecrawl/news.json
 | `--tbs <qdr:h\|d\|w\|m\|y>`          | Time-based search filter                      |
 | `--location`                         | Location for search results                   |
 | `--country <code>`                   | Country code for search                       |
+| `--highlights`                       | Return query-relevant highlights per result   |
+| `--no-highlights`                    | Keep the original search snippets             |
 | `--scrape`                           | Also scrape full page content for each result |
 | `--scrape-formats`                   | Formats when scraping (default: markdown)     |
 | `-o, --output <path>`                | Output file path                              |


### PR DESCRIPTION
Fixes #168

## What

Syncs the bundled skill docs with the actual firecrawl-cli 1.19.27 command surface. Every claim in the issue was verified line-by-line against the command registrations in `src/index.ts` and `src/commands/` before changing anything; all seven checked out:

- interact: `--language <lang>` replaced with the registered `--bash` / `--python` / `--node` flags (and short flags corrected)
- scrape: `-H` documented as HTTP headers, actually `-H, --html` (raw HTML shortcut); format list completed
- download: examples moved to `firecrawl x download` (top-level `download` was removed); "all scrape options work" narrowed to the actually-registered subset
- parse: `.xhtml` removed (not in SUPPORTED_EXTENSIONS); format list completed
- monitor: minimum interval corrected to 5 minutes, matching the umbrella skill and docs
- search: `--highlights` / `--no-highlights` added
- umbrella skill/rules: version-neutral status example, `x download` in the workflow table, `@latest` instead of the stale `@1.19.6` pin

Credit to @igorgarbuz for the detailed report in #168.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/cli/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787852024&installation_model_id=11126&pr_number=170&repository=firecrawl%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fcli%2Fpull%2F170&signature=b4891f42ff676ef8b0b9e0d7ed5739b2f66ff7470cca95193d7ee526cec5c72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates bundled skill docs to match the current `firecrawl-cli` surface. Fixes #168 by correcting flags, formats, command names, and install guidance.

- Bug Fixes
  - Interact: replaced `--language` with `--bash`/`--python`/`--node`; corrected short flags.
  - Scrape: `-H` now documented as `-H, --html` (raw HTML shortcut); formats list completed.
  - Download: documented under `firecrawl experimental download` (`firecrawl x download`); examples updated; only supported scrape options listed.
  - Parse: removed XHTML; formats list completed (`markdown`, `html`, `rawHtml`, `links`, `images`, `summary`, `json`, `attributes`).
  - Monitor: minimum schedule is 5 minutes.
  - Search: added `--highlights` and `--no-highlights`.
  - CLI/rules: version-neutral status example; install pins use `firecrawl-cli@latest`; workflow table uses `x download`.

<sup>Written for commit 7bcb26da274177ef35eee80f5285a27013ec3b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

