### PR TITLE
fix(cli): bump firecrawl dep to 4.26.0 for proxy CONNECT fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@inquirer/prompts": "^8.2.1",
     "commander": "^14.0.2",
-    "firecrawl": "4.24.0",
+    "firecrawl": "4.26.0",
     "yaml": "^2.9.0",
     "zod-to-json-schema": "3.24.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^14.0.2
         version: 14.0.2
       firecrawl:
-        specifier: 4.24.0
-        version: 4.24.0
+        specifier: 4.26.0
+        version: 4.26.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -507,6 +507,10 @@ packages:
   '@vitest/utils@4.0.16':
     resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ansi-escapes@7.2.0:
     resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
     engines: {node: '>=18'}
@@ -526,8 +530,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -663,12 +667,12 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  firecrawl@4.24.0:
-    resolution: {integrity: sha512-kP9E3Up7eF/0Qe8x2tPU/Mcvx0v6Vks397Gkln1+gZKyLAGtIQNEW0+KZcDPS/meRPodGlVi4Z77doQ2Twq74w==}
+  firecrawl@4.26.0:
+    resolution: {integrity: sha512-v5LtkRmzN5wIJD7pLdNtZKFsE45adC3SRGK3xp+xa6m1NkiuR3Mreq4yFikjE9FIPAPESY9rHGtbvvr67QYf/Q==}
     engines: {node: '>=22.0.0'}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -719,6 +723,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -1391,6 +1399,12 @@ snapshots:
       '@vitest/pretty-format': 4.0.16
       tinyrainbow: 3.0.3
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ansi-escapes@7.2.0:
     dependencies:
       environment: 1.1.0
@@ -1403,13 +1417,15 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.15.2:
+  axios@1.18.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   braces@3.0.3:
     dependencies:
@@ -1553,16 +1569,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  firecrawl@4.24.0:
+  firecrawl@4.26.0:
     dependencies:
-      axios: 1.15.2
+      axios: 1.18.0
       typescript-event-target: 1.1.2
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
       - debug
+      - supports-color
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   form-data@4.0.5:
     dependencies:
@@ -1610,6 +1627,13 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@5.0.0: {}
 


### PR DESCRIPTION
## What

Bumps the `firecrawl` SDK dependency from `4.24.0` to `4.26.0` so the bundled `axios` upgrades from `1.15.2` to `1.18.0`.

Fixes #172.

## Why

`axios@1.15.2` (the exact pin inside firecrawl`4.24.0`) predates the CONNECT-tunneling fix shipped in `axios@1.16.1` ([axios/axios#10858](https://github.com/axios/axios/pull/10858), tracked by [axios#6320](https://github.com/axios/axios/issues/6320) / [axios#6330](https://github.com/axios/axios/issues/6330)). Pre-1.16.1 axios sends HTTPS requests through an HTTP proxy in forward-proxy style (`POST https://host/path HTTP/1.1`) instead of issuing a `CONNECT` tunnel, so every proxy that only handles `CONNECT` for HTTPS (xray, squid, tinyproxy, mitmproxy, ...) rejects CLI requests with a non-2xx.

Observed in the wild behind `https_proxy=http://127.0.0.1:10808`:

```
$ firecrawl scrape "https://example.com" --json
Error: Request failed with status code 404
```

Workaround until now: `no_proxy=api.firecrawl.dev firecrawl scrape ...` (forces the SDK to skip the proxy).

The smallest change that resolves the bug is bumping the firecrawl dep. The axios CONNECT fix first ships in `firecrawl@4.25.5` (which bundles `axios@1.16.1`); `4.26.0` bundles the newer `axios@1.18.0` and was chosen to pick up the latest patch in the fix line while keeping the diff minimal. Bumping only to `4.26.0` (rather than straight to `4.31.1`) avoids pulling in unrelated changes from later SDK releases.

## How I verified

| Check | Result |
| --- | --- |
| `pnpm type-check` | clean |
| `pnpm test` (vitest) | 390 passed, 1 skipped (no new failures vs baseline) |
| `axios@1.15.2` through local xray proxy | ERR status=400 (bug reproduced) |
| `axios@1.18.0` through same proxy | 200 OK (CONNECT tunneling works) |

Smoke-test capture (ad-hoc script, not included in this PR):

```
$ node scripts/smoke-proxy.cjs node_modules/.pnpm/axios@1.18.0/node_modules/axios https://example.com
axios version: 1.18.0
OK status=200 bytes=559

$ node scripts/smoke-proxy.cjs node_modules/.pnpm/axios@1.15.2/node_modules/axios https://example.com
axios version: 1.15.2
ERR status=400
```

## Risk

Low. The CLI only consumes public SDK types (`Firecrawl`, `FirecrawlClientOptions`, `FormatOption`, `AgentWebhookConfig`) and constructor patterns that are stable across `4.24.0` -> `4.26.0`. Type-check and full vitest suite pass with no source changes.

## Alternatives considered

- `pnpm.overrides` forcing `axios` to `>=1.16.1` while keeping `firecrawl` at `4.24.0`. Works, but forks the dep graph away from what the SDK authors publish; a bump is the upstream-aligned fix.
- Bump straight to latest `4.31.1`. Also works, but pulls in seven minor versions of unrelated changes. Bumping only to `4.26.0` keeps the diff minimal and the review surface focused on the proxy bug.

## AI assistance disclosure

This pull request was prepared with AI assistance. An AI agent (Sisyphus, running on GLM 5.2 via OhMyOpenCode) performed the dependency analysis, ran the verification steps described above, and authored the initial commit and PR description. The fix itself (a one-line dependency bump) was verified manually: the type-check, test suite, and proxy smoke test were all executed and confirmed by the human author before opening this PR. A separate AI-assisted code review (Oracle subagent) was also run on the diff; its findings (a factual correction to the minimum-version claim, now applied) are reflected in this description.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/cli/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787929703&installation_model_id=11126&pr_number=173&repository=firecrawl%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fcli%2Fpull%2F173&signature=a0dfe655584b3850eec28b3e779811d9db0308784bb25f56656004653bef92c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `firecrawl` to 4.26.0 to pull in `axios@1.18.0`, fixing HTTPS proxy CONNECT tunneling so the CLI works behind HTTP(S) proxies. Fixes #172.

- **Bug Fixes**
  - HTTPS requests now tunnel via CONNECT behind proxies (e.g., squid, mitmproxy).
  - The `no_proxy=api.firecrawl.dev` workaround is no longer needed.

<sup>Written for commit 22ad2b64350e20e3efa0f7644e471949a038f612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
