### PR TITLE
feat(cli): add --skills-only to the developer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ firecrawl developer "axum middleware ordering"
 | Option                | Description                               |
 | --------------------- | ----------------------------------------- |
 | `--limit <n>`         | Number of results (default: 20, max: 100) |
+| `--skills-only`       | Search only agent-skill files             |
 | `-o, --output <path>` | Save to file                              |
 | `--json`              | Output as compact JSON                    |
 | `--pretty`            | Pretty print JSON output                  |

--- a/src/__tests__/cli-argv.test.ts
+++ b/src/__tests__/cli-argv.test.ts
@@ -30,6 +30,7 @@ describe('CLI argv parsing', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Usage: firecrawl developer');
     expect(result.stdout).toContain('--limit');
+    expect(result.stdout).toContain('--skills-only');
     expect(result.stderr).not.toContain('unknown command');
   });
 

--- a/src/__tests__/commands/developer.test.ts
+++ b/src/__tests__/commands/developer.test.ts
@@ -67,6 +67,19 @@ describe('handleDeveloperSearchCommand', () => {
       );
     });
 
+    it('passes skills=only when skillsOnly is set', async () => {
+      mockHttpGet.mockResolvedValue(mockDeveloperResponse([sampleResult]));
+
+      await handleDeveloperSearchCommand({
+        query: 'tokio spawn_blocking',
+        skillsOnly: true,
+      });
+
+      expect(mockHttpGet).toHaveBeenCalledWith(
+        '/v2/developer/search?query=tokio+spawn_blocking&skills=only&integration=cli'
+      );
+    });
+
     it('passes k when a limit is provided', async () => {
       mockHttpGet.mockResolvedValue(mockDeveloperResponse([sampleResult]));
 

--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -69,6 +69,7 @@ export async function handleDeveloperSearchCommand(
     const params = new URLSearchParams();
     params.append('query', options.query);
     if (options.k != null) params.append('k', String(options.k));
+    if (options.skillsOnly) params.append('skills', 'only');
     const data = await getDeveloper<{ results?: DeveloperItem[] }>(
       `${BASE}?${params.toString()}`,
       options

--- a/src/index.ts
+++ b/src/index.ts
@@ -1063,6 +1063,7 @@ function createDeveloperCommand(): Command {
       parseInt
     )
     .addOption(new Option('--k <number>').argParser(parseInt).hideHelp())
+    .option('--skills-only', 'Search only agent-skill files', false)
     .option(
       '-k, --api-key <key>',
       'Firecrawl API key (overrides global --api-key)'
@@ -1083,6 +1084,7 @@ Examples:
       await handleDeveloperSearchCommand({
         query,
         k: researchLimit(options),
+        skillsOnly: options.skillsOnly,
         apiKey: options.apiKey,
         apiUrl: options.apiUrl,
         output: options.output,

--- a/src/types/developer.ts
+++ b/src/types/developer.ts
@@ -1,6 +1,7 @@
 export interface DeveloperSearchOptions {
   query: string;
   k?: number;
+  skillsOnly?: boolean;
   apiKey?: string;
   apiUrl?: string;
   output?: string;


### PR DESCRIPTION
firecrawl/firecrawl#4194 (merged) exposes a `skills` query param on GET /v2/developer/search, validated as `z.enum(["only"]).optional()`. `firecrawl developer` gains a `--skills-only` boolean flag that maps to `skills=only`, which limits the search to agent-skill files. One help line, one README table row.

The param is absent from the request when the flag is omitted — the existing test pins the exact request URL, and a new test proves `skills=only` is appended. The root help test still lists the command and now checks the flag. The gateway side is already merged, so the flag works on arrival; the prod deploy had not picked it up yet at the time of writing (the API still rejects the key), which only affects when the value starts filtering, not this client change.

Tests: 407 pass (was 406). Type-check, format, and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4vZ6XH65bUJDkLthyfmvC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/cli/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788288969&installation_model_id=11126&pr_number=177&repository=firecrawl%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fcli%2Fpull%2F177&signature=9c798c7d3c2633bf568e67fe5665e88867c04ba382e7ddb8dbb79c7967a190b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a --skills-only flag to the developer command to search only agent-skill files. When set, the CLI sends skills=only to /v2/developer/search; help text and README updated. The param is omitted when the flag is not used.

<sup>Written for commit 131b49bec29f705ddd6a6426746b7f33d4fbaa51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

