### PR TITLE
chore(cli): point developer search at /v2/search/developer for GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ firecrawl developer "axum middleware ordering"
 
 | Option                | Description                               |
 | --------------------- | ----------------------------------------- |
-| `--limit <n>`         | Number of results (default: 20, max: 100) |
+| `--limit <n>`         | Number of results (default: 10, max: 100) |
 | `--skills-only`       | Search only agent-skill files             |
 | `-o, --output <path>` | Save to file                              |
 | `--json`              | Output as compact JSON                    |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.19.28",
+  "version": "1.19.29",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/commands/developer.test.ts
+++ b/src/__tests__/commands/developer.test.ts
@@ -23,7 +23,7 @@ describe('handleDeveloperSearchCommand', () => {
   let mockHttpGet: ReturnType<typeof vi.fn>;
 
   // Wrap a payload in the axios envelope returned by `client.http.get`.
-  // Mirrors the `/v2/developer/search` response shape:
+  // Mirrors the `/v2/search/developer` response shape:
   //   { success, results: [{ id, type, url, title, passages: [{ text }] }] }
   const mockDeveloperResponse = (results: any[]) => ({
     data: { success: true, results },
@@ -56,14 +56,14 @@ describe('handleDeveloperSearchCommand', () => {
   });
 
   describe('API call generation', () => {
-    it('calls /v2/developer/search with the query and integration tag', async () => {
+    it('calls /v2/search/developer with the query and integration tag', async () => {
       mockHttpGet.mockResolvedValue(mockDeveloperResponse([sampleResult]));
 
       await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
 
       expect(mockHttpGet).toHaveBeenCalledTimes(1);
       expect(mockHttpGet).toHaveBeenCalledWith(
-        '/v2/developer/search?query=tokio+spawn_blocking&integration=cli'
+        '/v2/search/developer?query=tokio+spawn_blocking&integration=cli'
       );
     });
 
@@ -76,7 +76,7 @@ describe('handleDeveloperSearchCommand', () => {
       });
 
       expect(mockHttpGet).toHaveBeenCalledWith(
-        '/v2/developer/search?query=tokio+spawn_blocking&skills=only&integration=cli'
+        '/v2/search/developer?query=tokio+spawn_blocking&skills=only&integration=cli'
       );
     });
 
@@ -89,7 +89,7 @@ describe('handleDeveloperSearchCommand', () => {
       });
 
       expect(mockHttpGet).toHaveBeenCalledWith(
-        '/v2/developer/search?query=tokio+spawn_blocking&k=5&integration=cli'
+        '/v2/search/developer?query=tokio+spawn_blocking&k=5&integration=cli'
       );
     });
 

--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -2,7 +2,9 @@ import { getClient, isKeylessMode, keylessGet } from '../utils/client';
 import { writeOutput } from '../utils/output';
 import type { DeveloperItem, DeveloperSearchOptions } from '../types/developer';
 
-const BASE = '/v2/developer/search';
+// The other mount, /v2/developer/search, rejects keyless callers and may be
+// withdrawn.
+const BASE = '/v2/search/developer';
 const MAX_PASSAGE_CHARS = 1200;
 
 async function getDeveloper<T>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1059,7 +1059,7 @@ function createDeveloperCommand(): Command {
     .argument('<query>', 'Natural-language developer question or search phrase')
     .option(
       '--limit <number>',
-      'Number of results to return (default: 20, max: 100)',
+      'Number of results to return (default: 10, max: 100)',
       parseInt
     )
     .addOption(new Option('--k <number>').argParser(parseInt).hideHelp())


### PR DESCRIPTION
The developer command calls `/v2/developer/search`. Two problems with that path.

It is the path that may be withdrawn. `/v2/search/developer` is the public one, and a published CLI cannot be re-pointed after the fact.

It also rejects a keyless caller. The API mounts the two paths with different auth: `/v2/search/developer` passes `allowKeyless: true`, `/v2/developer/search` does not. The CLI has a keyless mode, so `firecrawl developer "..."` without a key has never reached the index — it 401s in the middleware. The route change fixes that too.

Also corrects a stale fact: the API returns 10 results by default, not 20. The CLI sends no `k` of its own, so the server default is what a user gets.

## No beta gate here

There is no client-side beta gate to remove. The developer command registers unconditionally and carries no beta labelling. The only gate is server-side: an entitlement check on `developerBeta` in the API controller. This PR is independent of that flag removal and can merge in either order.

## Testing

`pnpm run format:check`, `pnpm run type-check`, `pnpm run build`, `pnpm test` — all pass (404 tests). `firecrawl developer --help` renders the corrected default.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/cli/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461450&installation_model_id=11126&pr_number=180&repository=firecrawl%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fcli%2Fpull%2F180&signature=818d50d8896d31008257bb7471eb8b63b528e0fc4fe679da2934c1179f11629f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the developer command to `/v2/search/developer` (public GA path) so keyless mode works and the path stays stable. Corrected the default results to 10 in `--help` and the README.

<sup>Written for commit cb862f29ee6f223443bcdbb10e63fd82b1a2a777. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

