### PR TITLE
fix(cli): restore authenticated MCP launch flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.19.29",
+  "version": "1.19.30",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/cli-argv.test.ts
+++ b/src/__tests__/cli-argv.test.ts
@@ -35,6 +35,29 @@ describe('CLI argv parsing', () => {
   });
 
   testWithBuiltCli(
+    'exposes explicit keyless MCP setup and launch flags',
+    () => {
+      const setup = spawnSync(process.execPath, [cliPath, 'setup', '--help'], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+      });
+      const launch = spawnSync(
+        process.execPath,
+        [cliPath, 'launch', '--help'],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8',
+        }
+      );
+
+      expect(setup.status).toBe(0);
+      expect(setup.stdout).toContain('--keyless');
+      expect(launch.status).toBe(0);
+      expect(launch.stdout).toContain('--keyless');
+    }
+  );
+
+  testWithBuiltCli(
     'parses subcommands when a wrapper leaves the entry script path in argv',
     () => {
       const script = `

--- a/src/__tests__/commands/launch.test.ts
+++ b/src/__tests__/commands/launch.test.ts
@@ -2,13 +2,9 @@ import { spawnSync } from 'child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { select } from '@inquirer/prompts';
 import { handleLaunchCommand } from '../../commands/launch';
-import {
-  installHermesMcp,
-  installMcp,
-  installOpenClawMcp,
-  installSkillsForAgent,
-} from '../../commands/setup';
+import { installMcp, installSkillsForAgent } from '../../commands/setup';
 import { ALL_SKILL_REPOS } from '../../commands/skills-install';
+import { getApiKey } from '../../utils/config';
 
 vi.mock('child_process', () => ({
   spawnSync: vi.fn(),
@@ -19,17 +15,23 @@ vi.mock('@inquirer/prompts', () => ({
 }));
 
 vi.mock('../../commands/setup', () => ({
-  installHermesMcp: vi.fn(async () => undefined),
   installMcp: vi.fn(async () => undefined),
-  installOpenClawMcp: vi.fn(async () => undefined),
   installSkillsForAgent: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../utils/config', () => ({
+  getApiKey: vi.fn(() => undefined),
 }));
 
 describe('handleLaunchCommand', () => {
   const originalIsTty = process.stdin.isTTY;
+  let originalApiKey: string | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getApiKey).mockReturnValue(undefined);
+    originalApiKey = process.env.FIRECRAWL_API_KEY;
+    delete process.env.FIRECRAWL_API_KEY;
     vi.mocked(spawnSync).mockReturnValue({ status: 0 } as never);
     Object.defineProperty(process.stdin, 'isTTY', {
       configurable: true,
@@ -38,6 +40,8 @@ describe('handleLaunchCommand', () => {
   });
 
   afterEach(() => {
+    if (originalApiKey === undefined) delete process.env.FIRECRAWL_API_KEY;
+    else process.env.FIRECRAWL_API_KEY = originalApiKey;
     Object.defineProperty(process.stdin, 'isTTY', {
       configurable: true,
       value: originalIsTty,
@@ -110,6 +114,23 @@ describe('handleLaunchCommand', () => {
     );
   });
 
+  it('warns when a GUI client may not inherit a launch-scoped stored key', async () => {
+    vi.mocked(getApiKey).mockReturnValue('fc-stored-key');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      await handleLaunchCommand('code', { skipSkills: true });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'may reuse an existing GUI process that cannot inherit the stored API key'
+        )
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('passes extra arguments through to Codex', async () => {
     await handleLaunchCommand('codex', {}, ['--sandbox', 'workspace-write']);
 
@@ -135,6 +156,47 @@ describe('handleLaunchCommand', () => {
       ['--sandbox', 'workspace-write'],
       expect.objectContaining({ stdio: 'inherit' })
     );
+  });
+
+  it('keeps a stored API key indirect while launching an agent with authenticated MCP', async () => {
+    vi.mocked(getApiKey).mockReturnValue('fc-stored-key');
+
+    await handleLaunchCommand('claude');
+
+    expect(installMcp).toHaveBeenCalledWith(
+      {
+        agent: 'claude-code',
+        global: true,
+        yes: true,
+        quiet: true,
+      },
+      expect.objectContaining({ FIRECRAWL_API_KEY: 'fc-stored-key' })
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      'claude',
+      [],
+      expect.objectContaining({
+        stdio: 'inherit',
+        env: expect.objectContaining({ FIRECRAWL_API_KEY: 'fc-stored-key' }),
+      })
+    );
+    expect(process.env.FIRECRAWL_API_KEY).toBeUndefined();
+  });
+
+  it('does not pretend a stored API key can persist beyond install-only mode', async () => {
+    vi.mocked(getApiKey).mockReturnValue('fc-stored-key');
+
+    await handleLaunchCommand('claude', { install: true });
+
+    expect(installMcp).toHaveBeenCalledWith({
+      agent: 'claude-code',
+      global: true,
+      yes: true,
+      quiet: true,
+    });
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(process.env.FIRECRAWL_API_KEY).toBeUndefined();
   });
 
   it('asks which Codex setup to run and can install MCP only', async () => {
@@ -251,7 +313,12 @@ describe('handleLaunchCommand', () => {
   it('configures Hermes MCP and skills, then launches Hermes Agent', async () => {
     await handleLaunchCommand('hermes');
 
-    expect(installHermesMcp).toHaveBeenCalled();
+    expect(installMcp).toHaveBeenCalledWith({
+      agent: 'hermes',
+      global: true,
+      yes: true,
+      quiet: true,
+    });
     expect(installSkillsForAgent).toHaveBeenCalledWith(
       'hermes-agent',
       {
@@ -273,10 +340,39 @@ describe('handleLaunchCommand', () => {
     );
   });
 
+  it('passes a stored API key only through the launched Hermes process environment', async () => {
+    vi.mocked(getApiKey).mockReturnValue('fc-stored-key');
+
+    await handleLaunchCommand('hermes');
+
+    expect(installMcp).toHaveBeenCalledWith(
+      {
+        agent: 'hermes',
+        global: true,
+        yes: true,
+        quiet: true,
+      },
+      expect.objectContaining({ FIRECRAWL_API_KEY: 'fc-stored-key' })
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      'hermes',
+      [],
+      expect.objectContaining({
+        env: expect.objectContaining({ FIRECRAWL_API_KEY: 'fc-stored-key' }),
+      })
+    );
+  });
+
   it('configures OpenClaw MCP and skills, then launches the TUI', async () => {
     await handleLaunchCommand('openclaw');
 
-    expect(installOpenClawMcp).toHaveBeenCalled();
+    expect(installMcp).toHaveBeenCalledWith({
+      agent: 'openclaw',
+      global: true,
+      yes: true,
+      quiet: true,
+    });
     expect(installSkillsForAgent).toHaveBeenCalledWith(
       'openclaw',
       {
@@ -301,8 +397,49 @@ describe('handleLaunchCommand', () => {
   it('can skip skills for Hermes and OpenClaw launch targets', async () => {
     await handleLaunchCommand('hermes', { skipSkills: true });
 
-    expect(installHermesMcp).toHaveBeenCalled();
+    expect(installMcp).toHaveBeenCalledWith({
+      agent: 'hermes',
+      global: true,
+      yes: true,
+      quiet: true,
+    });
     expect(installSkillsForAgent).not.toHaveBeenCalled();
+  });
+
+  it('can explicitly launch keyless without passing a stored API key to the client', async () => {
+    vi.mocked(getApiKey).mockReturnValue('fc-stored-key');
+
+    await handleLaunchCommand('claude', {
+      keyless: true,
+      skipSkills: true,
+    });
+
+    expect(installMcp).toHaveBeenCalledWith({
+      agent: 'claude-code',
+      global: true,
+      yes: true,
+      quiet: true,
+      keyless: true,
+    });
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      'claude',
+      [],
+      expect.objectContaining({
+        env: expect.not.objectContaining({
+          FIRECRAWL_API_KEY: 'fc-stored-key',
+        }),
+      })
+    );
+  });
+
+  it('rejects contradictory keyless and skip-MCP options', async () => {
+    await expect(
+      handleLaunchCommand('claude', { keyless: true, skipMcp: true })
+    ).rejects.toThrow('--keyless cannot be combined with --skip-mcp');
+
+    expect(installMcp).not.toHaveBeenCalled();
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 
   it('requires an explicit target in non-interactive mode', async () => {

--- a/src/__tests__/commands/launch.test.ts
+++ b/src/__tests__/commands/launch.test.ts
@@ -186,8 +186,15 @@ describe('handleLaunchCommand', () => {
 
   it('does not pretend a stored API key can persist beyond install-only mode', async () => {
     vi.mocked(getApiKey).mockReturnValue('fc-stored-key');
+    vi.mocked(installMcp).mockRejectedValueOnce(
+      new Error(
+        'Secure MCP setup cannot persist a stored API key for future client sessions. Export FIRECRAWL_API_KEY, launch the client through "firecrawl launch <agent>", or configure keyless MCP.'
+      )
+    );
 
-    await handleLaunchCommand('claude', { install: true });
+    await expect(
+      handleLaunchCommand('claude', { install: true })
+    ).rejects.toThrow('Export FIRECRAWL_API_KEY');
 
     expect(installMcp).toHaveBeenCalledWith({
       agent: 'claude-code',
@@ -406,32 +413,39 @@ describe('handleLaunchCommand', () => {
     expect(installSkillsForAgent).not.toHaveBeenCalled();
   });
 
-  it('can explicitly launch keyless without passing a stored API key to the client', async () => {
-    vi.mocked(getApiKey).mockReturnValue('fc-stored-key');
+  it.each([
+    ['claude', 'claude-code', 'claude', []],
+    ['hermes', 'hermes', 'hermes', []],
+    ['openclaw', 'openclaw', 'openclaw', ['tui']],
+  ])(
+    'can explicitly launch %s keyless without passing a stored API key to the client',
+    async (target, mcpAgent, command, args) => {
+      vi.mocked(getApiKey).mockReturnValue('fc-stored-key');
 
-    await handleLaunchCommand('claude', {
-      keyless: true,
-      skipSkills: true,
-    });
+      await handleLaunchCommand(target, {
+        keyless: true,
+        skipSkills: true,
+      });
 
-    expect(installMcp).toHaveBeenCalledWith({
-      agent: 'claude-code',
-      global: true,
-      yes: true,
-      quiet: true,
-      keyless: true,
-    });
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      2,
-      'claude',
-      [],
-      expect.objectContaining({
-        env: expect.not.objectContaining({
-          FIRECRAWL_API_KEY: 'fc-stored-key',
-        }),
-      })
-    );
-  });
+      expect(installMcp).toHaveBeenCalledWith({
+        agent: mcpAgent,
+        global: true,
+        yes: true,
+        quiet: true,
+        keyless: true,
+      });
+      expect(spawnSync).toHaveBeenNthCalledWith(
+        2,
+        command,
+        args,
+        expect.objectContaining({
+          env: expect.not.objectContaining({
+            FIRECRAWL_API_KEY: 'fc-stored-key',
+          }),
+        })
+      );
+    }
+  );
 
   it('rejects contradictory keyless and skip-MCP options', async () => {
     await expect(

--- a/src/__tests__/commands/setup.test.ts
+++ b/src/__tests__/commands/setup.test.ts
@@ -235,6 +235,22 @@ describe('handleSetupCommand', () => {
       'fc-test-key'
     );
   });
+  it('accepts a launch-scoped environment while keeping the stored key out of MCP config and argv', async () => {
+    await installMcp(
+      {
+        agent: 'claude-code',
+        global: true,
+        yes: true,
+      },
+      { ...process.env, FIRECRAWL_API_KEY: 'fc-test-key' }
+    );
+
+    const args = vi.mocked(execFileSync).mock.calls[0]?.[1];
+    expect(args).toContain('Authorization: Bearer ${FIRECRAWL_API_KEY}');
+    expect(args?.join(' ')).not.toContain('fc-test-key');
+    const subprocessEnv = vi.mocked(execFileSync).mock.calls[0]?.[2]?.env;
+    expect(subprocessEnv?.FIRECRAWL_API_KEY).toBeUndefined();
+  });
   it('normalizes launch aliases for environment-backed MCP setup', async () => {
     process.env.FIRECRAWL_API_KEY = 'fc-test-key';
 
@@ -390,6 +406,27 @@ describe('handleSetupCommand', () => {
     }
   });
 
+  it('honors explicit keyless setup for Hermes even when a key is stored', async () => {
+    const home = mkdtempSync(
+      path.join(os.tmpdir(), 'firecrawl-hermes-keyless-test-')
+    );
+    process.env.HOME = home;
+
+    try {
+      await installMcp({ agent: 'hermes', keyless: true });
+
+      const config = readFileSync(
+        path.join(home, '.hermes', 'config.yaml'),
+        'utf-8'
+      );
+      expect(config).toContain('https://mcp.firecrawl.dev/v2/mcp');
+      expect(config).not.toContain('Authorization');
+      expect(config).not.toContain('fc-test-key');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('rejects a stored key before invoking the OpenClaw CLI', async () => {
     await expect(installOpenClawMcp()).rejects.toThrow(
       'Export FIRECRAWL_API_KEY'
@@ -404,6 +441,15 @@ describe('handleSetupCommand', () => {
     const config = vi.mocked(execFileSync).mock.calls[0]?.[1]?.[3] as string;
     expect(config).toContain('Bearer ${FIRECRAWL_API_KEY}');
     expect(config).not.toContain('Bearer fc-test-key');
+  });
+
+  it('honors explicit keyless setup for OpenClaw even when a key is stored', async () => {
+    await installMcp({ agent: 'openclaw', keyless: true });
+
+    const config = vi.mocked(execFileSync).mock.calls[0]?.[1]?.[3] as string;
+    expect(config).toContain('https://mcp.firecrawl.dev/v2/mcp');
+    expect(config).not.toContain('Authorization');
+    expect(config).not.toContain('fc-test-key');
   });
 
   it('surfaces a sanitized OpenClaw setup failure', async () => {

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -3,13 +3,9 @@ import os from 'os';
 import path from 'path';
 import readline from 'readline';
 import { spawnSync } from 'child_process';
-import {
-  installHermesMcp,
-  installMcp,
-  installOpenClawMcp,
-  installSkillsForAgent,
-} from './setup';
+import { installMcp, installSkillsForAgent } from './setup';
 import { ALL_SKILL_REPOS } from './skills-install';
+import { getApiKey } from '../utils/config';
 
 export interface LaunchOptions {
   config?: boolean;
@@ -19,17 +15,18 @@ export interface LaunchOptions {
   yes?: boolean;
   skipMcp?: boolean;
   skipSkills?: boolean;
+  keyless?: boolean;
 }
 
 interface LaunchTarget {
   aliases: string[];
   displayName: string;
   mcpAgent?: string;
-  mcpInstaller?: () => Promise<void>;
   skillsAgent?: string;
   command: string;
   args?: string[];
   supportsExtraArgs?: boolean;
+  mayReuseGuiProcess?: boolean;
   fallbackCommand?: () => { command: string; args: string[] } | null;
 }
 
@@ -55,6 +52,7 @@ const TARGETS: LaunchTarget[] = [
     mcpAgent: 'vscode',
     command: 'code',
     args: ['.'],
+    mayReuseGuiProcess: true,
     fallbackCommand: () => {
       if (process.platform !== 'darwin') return null;
       return {
@@ -78,6 +76,7 @@ const TARGETS: LaunchTarget[] = [
     command: 'open',
     args: ['-b', 'com.openai.codex'],
     supportsExtraArgs: false,
+    mayReuseGuiProcess: true,
     fallbackCommand: () => {
       if (process.platform !== 'darwin') return null;
       return {
@@ -96,14 +95,14 @@ const TARGETS: LaunchTarget[] = [
   {
     aliases: ['hermes', 'hermes-agent'],
     displayName: 'Hermes Agent',
-    mcpInstaller: installHermesMcp,
+    mcpAgent: 'hermes',
     skillsAgent: 'hermes-agent',
     command: 'hermes',
   },
   {
     aliases: ['openclaw'],
     displayName: 'OpenClaw',
-    mcpInstaller: installOpenClawMcp,
+    mcpAgent: 'openclaw',
     skillsAgent: 'openclaw',
     command: 'openclaw',
     args: ['tui'],
@@ -232,6 +231,10 @@ export async function handleLaunchCommand(
   options: LaunchOptions = {},
   extraArgs: string[] = []
 ): Promise<void> {
+  if (options.keyless && options.skipMcp) {
+    throw new Error('--keyless cannot be combined with --skip-mcp.');
+  }
+
   if (!targetName && extraArgs.length > 0) {
     throw new Error(
       'Extra launch arguments require an explicit launch target.'
@@ -245,10 +248,18 @@ export async function handleLaunchCommand(
     );
   }
 
-  const targetSupportsMcp = Boolean(target.mcpInstaller || target.mcpAgent);
+  const targetSupportsMcp = Boolean(target.mcpAgent);
   const targetSupportsSkills = Boolean(target.skillsAgent);
   let installMcpForTarget = targetSupportsMcp && !options.skipMcp;
   let installSkillsForTarget = targetSupportsSkills && !options.skipSkills;
+  const installOnly = Boolean(
+    options.config || options.install || options.setup
+  );
+  const apiKey = options.keyless ? undefined : getApiKey();
+  const runtimeEnv =
+    !installOnly && apiKey && process.env.FIRECRAWL_API_KEY !== apiKey
+      ? { ...process.env, FIRECRAWL_API_KEY: apiKey }
+      : process.env;
 
   if (
     installMcpForTarget &&
@@ -262,15 +273,16 @@ export async function handleLaunchCommand(
   }
 
   if (installMcpForTarget) {
-    if (target.mcpInstaller) {
-      await target.mcpInstaller();
-    } else if (target.mcpAgent) {
-      await installMcp({
+    if (target.mcpAgent) {
+      const installOptions = {
         agent: target.mcpAgent,
         global: options.global !== false,
         yes: true,
         quiet: true,
-      });
+        ...(options.keyless ? { keyless: true } : {}),
+      };
+      if (runtimeEnv === process.env) await installMcp(installOptions);
+      else await installMcp(installOptions, runtimeEnv);
     }
   }
 
@@ -288,15 +300,21 @@ export async function handleLaunchCommand(
     );
   }
 
-  if (options.config || options.install || options.setup) {
+  if (installOnly) {
     console.log(`${target.displayName} is configured with Firecrawl MCP.`);
     return;
+  }
+
+  if (runtimeEnv !== process.env && target.mayReuseGuiProcess) {
+    console.warn(
+      `${target.displayName} may reuse an existing GUI process that cannot inherit the stored API key. If MCP authentication fails, export FIRECRAWL_API_KEY before opening the app.`
+    );
   }
 
   const launch = resolveLaunchCommand(target, extraArgs);
   const result = spawnSync(launch.command, launch.args, {
     stdio: 'inherit',
-    env: process.env,
+    env: runtimeEnv,
   });
 
   if (result.error) {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -183,14 +183,20 @@ function firecrawlHostedMcpUrl(): string {
   return 'https://mcp.firecrawl.dev/v2/mcp';
 }
 
-function isEnvironmentBackedApiKey(apiKey: string | undefined): boolean {
-  return Boolean(apiKey && process.env[ENV_API_KEY] === apiKey);
+function isEnvironmentBackedApiKey(
+  apiKey: string | undefined,
+  runtimeEnv: NodeJS.ProcessEnv = process.env
+): boolean {
+  return Boolean(apiKey && runtimeEnv[ENV_API_KEY] === apiKey);
 }
 
-function assertSubprocessSafeCredential(apiKey?: string): void {
-  if (apiKey && !isEnvironmentBackedApiKey(apiKey)) {
+function assertSubprocessSafeCredential(
+  apiKey?: string,
+  runtimeEnv: NodeJS.ProcessEnv = process.env
+): void {
+  if (apiKey && !isEnvironmentBackedApiKey(apiKey, runtimeEnv)) {
     throw new Error(
-      'Secure MCP setup cannot pass a stored API key to this client. Export FIRECRAWL_API_KEY and rerun with a supported --agent, or run keyless setup without a credential.'
+      'Secure MCP setup cannot persist a stored API key for future client sessions. Export FIRECRAWL_API_KEY, launch the client through "firecrawl launch <agent>", or configure keyless MCP.'
     );
   }
 }
@@ -213,14 +219,15 @@ function environmentHeaderForAgent(agent?: string): string | undefined {
 
 function firecrawlMcpHeaders(
   agent?: string,
-  apiKey?: string
+  apiKey?: string,
+  runtimeEnv: NodeJS.ProcessEnv = process.env
 ): Record<string, string> | undefined {
   if (!apiKey) return undefined;
 
   // Keep this helper safe in isolation. Callers currently reject stored keys
   // before reaching it, but a future call site must not turn one into a raw
   // Authorization header in argv or a client configuration file.
-  assertSubprocessSafeCredential(apiKey);
+  assertSubprocessSafeCredential(apiKey, runtimeEnv);
   const environmentHeader = environmentHeaderForAgent(agent);
   if (environmentHeader) return { Authorization: environmentHeader };
   throw new Error(
@@ -524,7 +531,13 @@ export async function installSkillsForAgent(
   );
 }
 
-export async function installMcp(options: SetupOptions): Promise<void> {
+export async function installMcp(
+  options: SetupOptions,
+  // `firecrawl launch` may provide the exact environment inherited by the
+  // client it starts. This lets MCP config keep an indirect env reference
+  // without mutating the parent shell or exposing the key to setup commands.
+  runtimeEnv: NodeJS.ProcessEnv = process.env
+): Promise<void> {
   if (options.global && options.project) {
     throw new Error('Choose either --global or --project, not both.');
   }
@@ -536,53 +549,64 @@ export async function installMcp(options: SetupOptions): Promise<void> {
       'Authenticated --agent all setup does not support --project because Codex requires a global environment-backed MCP configuration. Choose one --agent for project setup, use --agent all --global, or run keyless setup.'
     );
   }
-  if (!options.agent && isEnvironmentBackedApiKey(apiKey)) {
+  if (!options.agent && isEnvironmentBackedApiKey(apiKey, runtimeEnv)) {
     throw new Error(
       "Environment-backed MCP setup requires --agent so Firecrawl can use that client's native variable syntax. Choose a supported client or use --agent all; the API key will not be written literally."
     );
   }
   if (resolvedAgent.kind === 'hermes') {
-    await installHermesMcp();
+    await installHermesMcp(runtimeEnv, options.keyless);
     return;
   }
-  assertSubprocessSafeCredential(apiKey);
+  assertSubprocessSafeCredential(apiKey, runtimeEnv);
   if (resolvedAgent.kind === 'openclaw') {
-    await installOpenClawMcp();
+    await installOpenClawMcp(runtimeEnv, options.keyless);
     return;
   }
   if (resolvedAgent.kind === 'all-launchers') {
-    await installAllMcpLaunchers(options);
+    await installAllMcpLaunchers(options, runtimeEnv);
     return;
   }
 
-  await installAddMcp(options, resolvedAgent);
+  await installAddMcp(options, resolvedAgent, runtimeEnv);
 }
 
-async function installAllMcpLaunchers(options: SetupOptions): Promise<void> {
+async function installAllMcpLaunchers(
+  options: SetupOptions,
+  runtimeEnv: NodeJS.ProcessEnv
+): Promise<void> {
   for (const agent of ADD_MCP_LAUNCH_AGENTS) {
-    await installAddMcp({ ...options, yes: true }, { kind: 'add-mcp', agent });
+    await installAddMcp(
+      { ...options, yes: true },
+      { kind: 'add-mcp', agent },
+      runtimeEnv
+    );
   }
-  await installHermesMcp();
-  await installOpenClawMcp();
+  await installHermesMcp(runtimeEnv, options.keyless);
+  await installOpenClawMcp(runtimeEnv, options.keyless);
 }
 
 async function installAddMcp(
   options: SetupOptions,
-  resolvedAgent: Extract<ResolvedMcpAgent, { kind: 'add-mcp' }>
+  resolvedAgent: Extract<ResolvedMcpAgent, { kind: 'add-mcp' }>,
+  runtimeEnv: NodeJS.ProcessEnv
 ): Promise<void> {
   const mcpUrl = firecrawlHostedMcpUrl();
   const apiKey = options.keyless ? undefined : getApiKey();
+  // Codex has no Authorization template in environmentHeaderForAgent. Its
+  // native bearer-token option is the verified env indirection, so this must
+  // remain before the generic firecrawlMcpHeaders path.
   if (
     resolvedAgent.agent === 'codex' &&
     !options.project &&
     apiKey &&
-    isEnvironmentBackedApiKey(apiKey)
+    isEnvironmentBackedApiKey(apiKey, runtimeEnv)
   ) {
     installCodexMcpFromEnvironment(options, mcpUrl);
     return;
   }
 
-  const headers = firecrawlMcpHeaders(resolvedAgent.agent, apiKey);
+  const headers = firecrawlMcpHeaders(resolvedAgent.agent, apiKey, runtimeEnv);
   const useGlobal = !options.project && Boolean(options.global);
 
   const args = [
@@ -665,19 +689,30 @@ function installCodexMcpFromEnvironment(
   }
 }
 
-function firecrawlMcpConfig(agent?: string): {
+function firecrawlMcpConfig(
+  agent?: string,
+  runtimeEnv: NodeJS.ProcessEnv = process.env,
+  keyless = false
+): {
   url: string;
   headers?: Record<string, string>;
   transport?: string;
 } {
   return {
     url: firecrawlHostedMcpUrl(),
-    headers: firecrawlMcpHeaders(agent, getApiKey()),
+    headers: firecrawlMcpHeaders(
+      agent,
+      keyless ? undefined : getApiKey(),
+      runtimeEnv
+    ),
   };
 }
 
-export async function installHermesMcp(): Promise<void> {
-  const config = firecrawlMcpConfig('hermes');
+export async function installHermesMcp(
+  runtimeEnv: NodeJS.ProcessEnv = process.env,
+  keyless = false
+): Promise<void> {
+  const config = firecrawlMcpConfig('hermes', runtimeEnv, keyless);
   const configPath = path.join(os.homedir(), '.hermes', 'config.yaml');
   mkdirSync(path.dirname(configPath), { recursive: true });
 
@@ -704,9 +739,12 @@ export async function installHermesMcp(): Promise<void> {
   console.log(`Hermes Agent MCP configured at ${configPath}.`);
 }
 
-export async function installOpenClawMcp(): Promise<void> {
+export async function installOpenClawMcp(
+  runtimeEnv: NodeJS.ProcessEnv = process.env,
+  keyless = false
+): Promise<void> {
   const config = {
-    ...firecrawlMcpConfig('openclaw'),
+    ...firecrawlMcpConfig('openclaw', runtimeEnv, keyless),
     transport: 'streamable-http',
   };
   console.log('Configuring Firecrawl MCP for OpenClaw...\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -2251,6 +2251,10 @@ program
     'Skip prompts; for bare setup, install the default skills + MCP bundle'
   )
   .option(
+    '--keyless',
+    'Configure anonymous hosted MCP even when an API key is stored'
+  )
+  .option(
     '--undo',
     'Undo setup defaults by re-enabling native web tools where supported'
   )
@@ -2293,6 +2297,10 @@ program
   .option('--config', 'Alias for --install')
   .option('--skip-mcp', 'Launch without installing or updating Firecrawl MCP')
   .option('--skip-skills', 'Launch without installing Firecrawl skills')
+  .option(
+    '--keyless',
+    'Configure anonymous hosted MCP without an Authorization header'
+  )
   .option(
     '-g, --global',
     'Install Firecrawl MCP globally for the selected agent',


### PR DESCRIPTION
## Summary

Fixes the MCP launch regression introduced by credential hardening: `firecrawl init -k <key>` stored a credential that `firecrawl launch <agent>` subsequently refused because the MCP installer only recognized `process.env`.

- pass a stored key only in the environment of the agent launched by `firecrawl launch`
- keep MCP configuration indirect (`${FIRECRAWL_API_KEY}` or the client-native equivalent)
- never pass the stored key to `npx`, client setup argv, or client config
- preserve the fail-closed behavior for persistent `--install` / `--config` / `--setup`
- consolidate Hermes and OpenClaw through the common MCP installer
- expose explicit `--keyless` setup and launch flags
- fix Hermes and OpenClaw ignoring explicit keyless setup
- warn when VS Code or Codex App may reuse a GUI process that cannot inherit a launch-scoped key
- bump the CLI to `1.19.30`

## Authentication behavior

| Flow | Behavior |
| --- | --- |
| `launch <agent>` with stored key | configures `/v2/mcp` with an env reference and gives the key only to the launched agent |
| exported `FIRECRAWL_API_KEY` | preserves the existing environment-backed bearer flow |
| no key or explicit `--keyless` | configures `/v2/mcp` without an Authorization header |
| install-only with stored key | fails with actionable export / launch / keyless remedies |

## Security verification

Executed the original reproduction with isolated credentials and instrumented client shims:

- installer argv contained `Bearer ${FIRECRAWL_API_KEY}`, never the literal key
- the `npx` installer did not receive `FIRECRAWL_API_KEY`
- the client existence probe did not receive it
- only the final launched agent process received the stored key
- the literal key appeared only in the CLI credentials store

Also exercised the built CLI across Claude Code, VS Code, Codex, Codex App, OpenCode, Hermes, and OpenClaw, plus keyless `--agent all`.

## Verification

- `pnpm run format:check`
- `pnpm run type-check`
- `pnpm run build`
- `pnpm run test` (`417/417`)
- built-CLI authenticated launch matrix across all launch targets
- built-CLI keyless setup matrix across all launch integrations

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/cli/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788683310&installation_model_id=11126&pr_number=182&repository=firecrawl%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fcli%2Fpull%2F182&signature=d146fb67bcc518d2060bfa130ee314715795ec90699b86df2685237fef1e683b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores authenticated MCP launch by keeping configs env-referenced and scoping a stored API key to the launched agent’s environment. Adds explicit `--keyless` setup/launch and unifies Hermes/OpenClaw under a shared `installMcp`.

- **Bug Fixes**
  - Fixed regression where `firecrawl init -k` created a key that `firecrawl launch` rejected; the key now goes only to the child process env.
  - MCP configs stay indirect (`${FIRECRAWL_API_KEY}` or client-native); the literal key is never written to config, `npx`, or setup argv.
  - Preserved fail-closed behavior for install-only paths with clearer guidance (export key, launch via CLI, or use keyless); reject `--keyless` with `--skip-mcp`.
  - Warn when VS Code or Codex App may reuse a GUI process that can’t inherit a launch-scoped key.
  - Bumped CLI to `1.19.30`.

- **New Features**
  - Added `--keyless` to `setup` and `launch` for explicit anonymous MCP.
  - Consolidated Hermes and OpenClaw via shared `installMcp`; both honor keyless and env indirection.

<sup>Written for commit 4a791283bf514ebb7118e97487cb10e84b843343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

