### PR TITLE
fix(search): expose pretty JSON option

### DIFF
--- a/src/__tests__/cli-argv.test.ts
+++ b/src/__tests__/cli-argv.test.ts
@@ -34,6 +34,17 @@ describe('CLI argv parsing', () => {
     expect(result.stderr).not.toContain('unknown command');
   });
 
+  testWithBuiltCli('exposes pretty JSON output for search', () => {
+    const result = spawnSync(process.execPath, [cliPath, 'search', '--help'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: firecrawl search');
+    expect(result.stdout).toContain('--pretty');
+  });
+
   testWithBuiltCli(
     'exposes explicit keyless MCP setup and launch flags',
     () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -968,11 +968,11 @@ function createSearchCommand(): Command {
     )
     .option('--api-url <url>', 'API URL (overrides global --api-url)')
     .option('-o, --output <path>', 'Output file path (default: stdout)')
-    // .option(
-    //   '-p, --pretty',
-    //   'Output as pretty JSON (default: human-readable)',
-    //   false
-    // )
+    .option(
+      '-p, --pretty',
+      'Output as pretty JSON (default: human-readable)',
+      false
+    )
     .option('--json', 'Output as compact JSON', false)
     .action(async (query, options) => {
       // Parse sources


### PR DESCRIPTION
## Summary
- restore the `-p, --pretty` option registration for `firecrawl search`
- keep the existing search output behavior where `pretty` implies JSON output
- add CLI argv coverage so `firecrawl search --help` exposes `--pretty`

Closes #181

## Test Plan
- `pnpm run build`
- `pnpm vitest run src/__tests__/cli-argv.test.ts src/__tests__/commands/search.test.ts`
- `pnpm run format:check`

The new CLI argv test failed before the option registration was restored because search help did not include `--pretty`; it passes after the change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #181 by restoring the `-p, --pretty` flag for `firecrawl search` to enable pretty-printed JSON and show it in `--help`. Preserves behavior where `--pretty` implies JSON and adds a CLI argv test to prevent regressions.

<sup>Written for commit 4d18d6f46328570d760576f25dd4f578ebe38987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

