### PR TITLE
developer-search: tolerate removal of internal response fields

### DIFF
--- a/src/commands/research.ts
+++ b/src/commands/research.ts
@@ -149,7 +149,7 @@ function fmtGithub(results?: GitHubItem[]): string {
   return results
     .map((item) => {
       const lines: string[] = [];
-      if (item.resultType === 'repo_readme') {
+      if (item.number == null && item.pageType == null) {
         lines.push(`[${item.repo ?? '?'}] README`);
       } else {
         const ref = item.number != null ? `#${item.number}` : '';

--- a/src/types/research.ts
+++ b/src/types/research.ts
@@ -53,7 +53,6 @@ export interface PaperHit {
 }
 
 export interface GitHubItem {
-  resultType?: string;
   repo?: string;
   url?: string;
   pageType?: string;


### PR DESCRIPTION
## What

- Detect README results from the public result shape.
- Remove the `resultType` field from the CLI type.

## Why

The server no longer sends `resultType`. The CLI must keep the same README output without this field.

## Verified absent

The developer and search command surfaces do not use `coverage`, `reranked`, `variant`, `textKind`, or `resultType`.

## Not touched

The developer request and the user-visible output stay unchanged.