### PR TITLE
release: 1.19.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.19.30",
+  "version": "1.19.31",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Bump the version to 1.19.31.

The publish workflow runs on a main push that touches `package.json`. This bump releases #184 (tolerance for the removal of internal developer-search response fields) to npm.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `firecrawl-cli` v1.19.31 to publish tolerance for removed internal developer-search response fields to npm. Prevents errors when mechanism fields are missing.

<sup>Written for commit a947e4f71f4f9ce8b61ffb95102d1e94c199834a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

