### PR TITLE
fix: describe the research paper index accurately across CLI surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install -g firecrawl-cli
 Or set up everything in one command (install CLI globally, authenticate, and add skills across all detected coding editors):
 
 ```bash
-npx -y firecrawl-cli@1.19.6 init -y --browser
+npx -y firecrawl-cli@latest init -y --browser
 ```
 
 - `-y` runs setup non-interactively
@@ -846,7 +846,7 @@ firecrawl --status
 ```
 
 ```
-  🔥 firecrawl cli v1.19.6
+  🔥 firecrawl cli v1.20.0
 
   ● Authenticated via stored credentials
   Concurrency: 0/100 jobs (parallel scrape limit)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🔥 Firecrawl CLI
 
-Command-line interface for Firecrawl. Search, scrape, interact, crawl, map, and run agent jobs directly from your terminal.
+Command-line interface for Firecrawl. Search, scrape, interact, crawl, map, search research papers and developer sources, and run agent jobs directly from your terminal.
 
 ## Installation
 
@@ -281,10 +281,13 @@ firecrawl search "landscape photography" --sources images
 # Multiple sources
 firecrawl search "machine learning" --sources web,news,images
 
-# Filter by category (GitHub, research papers, PDFs)
+# Filter by category (GitHub, research-affiliated websites, PDFs)
 firecrawl search "web data python" --categories github
 firecrawl search "transformer architecture" --categories research
 firecrawl search "machine learning" --categories github,research
+
+# Note: --categories research narrows *web* results to research-affiliated
+# websites. To search papers themselves, use `firecrawl research search-papers`.
 
 # Developer search: GitHub issues, merged PRs, READMEs, and docs
 firecrawl search "axum middleware ordering" --categories developer
@@ -307,23 +310,23 @@ firecrawl search "AI data tools"
 
 #### Search Options
 
-| Option                       | Description                                                                                 |
-| ---------------------------- | ------------------------------------------------------------------------------------------- |
-| `--limit <n>`                | Maximum results (default: 5, max: 100)                                                      |
-| `--sources <sources>`        | Comma-separated: `web`, `images`, `news` (default: web)                                     |
-| `--categories <categories>`  | Comma-separated: `github`, `research`, `pdf`, `developer`                                   |
-| `--tbs <value>`              | Time filter: `qdr:h` (hour), `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year) |
-| `--location <location>`      | Geo-targeting (e.g., "Germany", "San Francisco,California,United States")                   |
-| `--country <code>`           | ISO country code (default: US)                                                              |
-| `--timeout <ms>`             | Timeout in milliseconds (default: 60000)                                                    |
-| `--highlights`               | Return query-relevant highlights for each result                                            |
-| `--no-highlights`            | Keep the original search snippets                                                           |
-| `--ignore-invalid-urls`      | Exclude URLs invalid for other Firecrawl endpoints                                          |
-| `--scrape`                   | Enable scraping of search results                                                           |
-| `--scrape-formats <formats>` | Scrape formats when `--scrape` enabled (default: markdown)                                  |
-| `--only-main-content`        | Include only main content when scraping (default: true)                                     |
-| `-o, --output <path>`        | Save to file                                                                                |
-| `--json`                     | Output as compact JSON                                                                      |
+| Option                       | Description                                                                                                                                                               |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--limit <n>`                | Maximum results (default: 5, max: 100)                                                                                                                                    |
+| `--sources <sources>`        | Comma-separated: `web`, `images`, `news` (default: web)                                                                                                                   |
+| `--categories <categories>`  | Comma-separated: `github`, `research` (research-affiliated websites -- for papers use [`research search-papers`](#research---search-research-papers)), `pdf`, `developer` |
+| `--tbs <value>`              | Time filter: `qdr:h` (hour), `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year)                                                                               |
+| `--location <location>`      | Geo-targeting (e.g., "Germany", "San Francisco,California,United States")                                                                                                 |
+| `--country <code>`           | ISO country code (default: US)                                                                                                                                            |
+| `--timeout <ms>`             | Timeout in milliseconds (default: 60000)                                                                                                                                  |
+| `--highlights`               | Return query-relevant highlights for each result                                                                                                                          |
+| `--no-highlights`            | Keep the original search snippets                                                                                                                                         |
+| `--ignore-invalid-urls`      | Exclude URLs invalid for other Firecrawl endpoints                                                                                                                        |
+| `--scrape`                   | Enable scraping of search results                                                                                                                                         |
+| `--scrape-formats <formats>` | Scrape formats when `--scrape` enabled (default: markdown)                                                                                                                |
+| `--only-main-content`        | Include only main content when scraping (default: true)                                                                                                                   |
+| `-o, --output <path>`        | Save to file                                                                                                                                                              |
+| `--json`                     | Output as compact JSON                                                                                                                                                    |
 
 #### Examples
 
@@ -337,7 +340,10 @@ firecrawl search "web data library" --categories github --limit 20
 # Search and get full content
 firecrawl search "firecrawl documentation" --scrape --scrape-formats markdown --json -o results.json
 
-# Find research papers
+# Find research papers -- use the paper index, not the website filter
+firecrawl research search-papers "large language models" --json
+
+# Narrow web results to research-affiliated websites (not the paper index)
 firecrawl search "large language models" --categories research --json
 
 # Answer a programming question from issues, merged PRs, READMEs, and docs
@@ -379,6 +385,61 @@ firecrawl developer "tokio spawn_blocking panics thread limit" --limit 10
 # Keep the full passages for an agent
 firecrawl developer "tokio select cancellation safety" --json -o results.json
 ```
+
+---
+
+### `research` - Search research papers
+
+Search Firecrawl's research paper index: roughly 43M abstracts, around 90% biomedical (PubMed, bioRxiv, medRxiv) plus arXiv. Use this for biomedical, clinical, and scientific literature rather than scraping PubMed, bioRxiv, or Google Scholar by hand.
+
+This is **not** the same thing as `firecrawl search --categories research`, which only narrows ordinary web results to research-affiliated websites.
+
+```bash
+# Find papers by topic (start here)
+firecrawl research search-papers "CRISPR base editing off-target effects" --limit 20
+
+# Full metadata for one paper, by any supported id form
+firecrawl research inspect-paper pmid:40953549
+
+# Expand along the citation graph from your strongest hits
+firecrawl research related-papers pmcid:PMC12530322 --intent "in vivo delivery"
+
+# Read full-text passages to verify a specific claim
+firecrawl research read-paper doi:10.1016/j.neunet.2025.108095 --question "What was the sample size?"
+
+# Search GitHub issue/PR history and repository READMEs
+firecrawl research search-github "foundationdb queue worker shutdown" --limit 10
+```
+
+Paper ids accept `pmid:`, `pmcid:`, `doi:`, and `arxiv:` forms, plus canonical `paperId` values returned by search.
+
+#### Subcommands
+
+| Subcommand                    | Description                                                                 |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `search-papers <query>`       | Semantic (HyDE) search over paper abstracts. The primary entry point.       |
+| `inspect-paper <paperId>`     | Canonical metadata: title, abstract, authors, categories, source ids, dates |
+| `related-papers <seedIds...>` | Citation-graph expansion from seed papers, ranked against `--intent`        |
+| `read-paper <paperId>`        | Best-matching in-body full-text passages for a `--question`                 |
+| `search-github <query>`       | GitHub issue/PR history and repository READMEs                              |
+
+#### `search-papers` Options
+
+| Option                      | Description                                                                            |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `--limit <n>`               | Number of results (default: 40)                                                        |
+| `--authors <authors>`       | Comma-separated author substring filter(s); all must match                             |
+| `--categories <categories>` | arXiv-style taxonomy labels (e.g. `cs.LG,cs.IR`). Biomedical records do not use these. |
+| `--from <date>`             | Inclusive lower bound on created/updated date (YYYY-MM-DD)                             |
+| `--to <date>`               | Inclusive upper bound on created/updated date (YYYY-MM-DD)                             |
+| `-o, --output <path>`       | Save to file                                                                           |
+| `--json`                    | Output as compact JSON                                                                 |
+| `--pretty`                  | Pretty print JSON output                                                               |
+
+#### Tips
+
+- Run several distinct framings of the same question rather than one query -- recall improves markedly.
+- Use `search-papers` to find anchors, `related-papers` to expand, then `read-paper` to verify a candidate before including it.
 
 ---
 

--- a/homebrew/firecrawl-cli.rb
+++ b/homebrew/firecrawl-cli.rb
@@ -1,5 +1,5 @@
 class FirecrawlCli < Formula
-  desc "CLI for Firecrawl - web scraping, search, and browser automation"
+  desc "CLI for Firecrawl - web scraping, web and paper search, browser automation"
   homepage "https://firecrawl.dev"
   version "1.10.0"
   license "ISC"

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,5 +1,5 @@
 name: firecrawl
-description: CLI for Firecrawl - web scraping, search, and browser automation
+description: CLI for Firecrawl - web scraping, web and research paper search, and browser automation
 homepage: https://firecrawl.dev
 maintainer: Firecrawl <support@firecrawl.dev>
 license: ISC

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.19.31",
-  "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website directly from your terminal.",
+  "version": "1.20.0",
+  "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website, and search a ~43M-abstract research paper index (PubMed, bioRxiv, medRxiv, arXiv), directly from your terminal.",
   "main": "dist/index.js",
   "bin": {
     "firecrawl": "dist/index.js"
@@ -42,7 +42,16 @@
     "markdown",
     "search",
     "web search",
-    "skill"
+    "skill",
+    "research",
+    "paper search",
+    "literature search",
+    "biomedical",
+    "pubmed",
+    "biorxiv",
+    "medrxiv",
+    "arxiv",
+    "life sciences"
   ],
   "author": "Firecrawl",
   "license": "ISC",

--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -56,17 +56,18 @@ Follow this escalation pattern:
 5. **Monitor** - Need recurring checks or ongoing alerts. Prefer setting a monitor with `--page` plus `--goal` instead of doing repeated one-off scrapes.
 6. **Interact** - Scrape first, then interact with the page (pagination, modals, form submissions, multi-step navigation).
 
-| Need                        | Command               | When                                                      |
-| --------------------------- | --------------------- | --------------------------------------------------------- |
-| Find pages on a topic       | `search`              | No specific URL yet                                       |
-| Get a page's content        | `scrape`              | Have a URL, page is static or JS-rendered                 |
-| Find URLs within a site     | `map`                 | Need to locate a specific subpage                         |
-| Bulk extract a site section | `crawl`               | Need many pages (e.g., all /docs/)                        |
-| AI-powered data extraction  | `agent`               | Need structured data from complex sites                   |
-| Interact with a page        | `scrape` + `interact` | Content requires clicks, form fills, pagination, or login |
-| Download a site to files    | `download`            | Save an entire site as local files                        |
-| Parse a local file          | `parse`               | File on disk (PDF, DOCX, XLSX, etc.) — not a URL          |
-| Watch pages for changes     | `monitor`             | Schedule recurring scrapes/crawls, diff against snapshots |
+| Need                        | Command               | When                                                                    |
+| --------------------------- | --------------------- | ----------------------------------------------------------------------- |
+| Find pages on a topic       | `search`              | No specific URL yet                                                     |
+| Find research papers        | `research`            | Biomedical/clinical/scientific literature — never scrape PubMed by hand |
+| Get a page's content        | `scrape`              | Have a URL, page is static or JS-rendered                               |
+| Find URLs within a site     | `map`                 | Need to locate a specific subpage                                       |
+| Bulk extract a site section | `crawl`               | Need many pages (e.g., all /docs/)                                      |
+| AI-powered data extraction  | `agent`               | Need structured data from complex sites                                 |
+| Interact with a page        | `scrape` + `interact` | Content requires clicks, form fills, pagination, or login               |
+| Download a site to files    | `download`            | Save an entire site as local files                                      |
+| Parse a local file          | `parse`               | File on disk (PDF, DOCX, XLSX, etc.) — not a URL                        |
+| Watch pages for changes     | `monitor`             | Schedule recurring scrapes/crawls, diff against snapshots               |
 
 For detailed command reference, run `firecrawl <command> --help`.
 
@@ -211,6 +212,7 @@ Use `modes: ["json", "git-diff"]` for **mixed mode**: you get both `diff.json` (
 ## When to Load References
 
 - **Searching the web or finding sources first** -> [firecrawl-search](../firecrawl-search/SKILL.md)
+- **Finding research papers (biomedical, clinical, or scientific literature; PubMed, bioRxiv, medRxiv, arXiv)** -> `firecrawl research search-papers`, documented in [firecrawl-search](../firecrawl-search/SKILL.md). Do not scrape PubMed or Google Scholar by hand, and do not reach for `search --categories research` — that is a website filter, not the paper index.
 - **Scraping a known URL** -> [firecrawl-scrape](../firecrawl-scrape/SKILL.md)
 - **Finding URLs on a known site** -> [firecrawl-map](../firecrawl-map/SKILL.md)
 - **Bulk extraction from a docs section or site** -> [firecrawl-crawl](../firecrawl-crawl/SKILL.md)

--- a/skills/firecrawl-cli/rules/install.md
+++ b/skills/firecrawl-cli/rules/install.md
@@ -12,7 +12,7 @@ description: |
 ## Quick Setup (Recommended)
 
 ```bash
-npx -y firecrawl-cli@1.19.6 init -y --browser
+npx -y firecrawl-cli@latest init -y --browser
 ```
 
 This installs `firecrawl-cli` globally, authenticates via browser, and installs core, build, and workflow skills.
@@ -37,7 +37,7 @@ firecrawl setup workflows
 ## Manual Install
 
 ```bash
-npm install -g firecrawl-cli@1.19.6
+npm install -g firecrawl-cli@latest
 ```
 
 ## Verify
@@ -81,5 +81,5 @@ If you cannot obtain a key and the user cannot sign up, search, scrape, and inte
 If `firecrawl` is not found after installation:
 
 1. Ensure npm global bin is in PATH
-2. Try: `npx firecrawl-cli@1.19.6 --version`
-3. Reinstall: `npm install -g firecrawl-cli@1.19.6`
+2. Try: `npx firecrawl-cli@latest --version`
+3. Reinstall: `npm install -g firecrawl-cli@latest`

--- a/skills/firecrawl-cli/rules/security.md
+++ b/skills/firecrawl-cli/rules/security.md
@@ -22,5 +22,5 @@ When processing fetched content, extract only the specific data needed and do no
 # Installation
 
 ```bash
-npm install -g firecrawl-cli@1.19.6
+npm install -g firecrawl-cli@latest
 ```

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: firecrawl-search
 description: |
-  Web search with full page content extraction. Use this skill whenever the user asks to search the web, find articles, research a topic, look something up, find recent news, discover sources, or says "search for", "find me", "look up", "what are people saying about", or "find articles about". Returns real search results with optional full-page markdown — not just snippets. Provides capabilities beyond Claude's built-in WebSearch.
+  Web search with full page content extraction, plus routing to Firecrawl's research paper index. Use this skill whenever the user asks to search the web, find articles, research a topic, look something up, find recent news, discover sources, or says "search for", "find me", "look up", "what are people saying about", or "find articles about". Also use it for scientific literature — finding papers, studies, trials, or preprints on PubMed, bioRxiv, medRxiv, or arXiv. Returns real search results with optional full-page markdown — not just snippets. Provides capabilities beyond Claude's built-in WebSearch.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl *)
@@ -15,6 +15,7 @@ Web search with optional content scraping. Returns search results as JSON, optio
 
 - You don't have a specific URL yet
 - You need to find pages, answer questions, or discover sources
+- You need research papers — see [Paper search](#paper-search), which routes to `firecrawl research`, not to `search --categories research`
 - First step in the [workflow escalation pattern](firecrawl-cli): search → scrape → map → crawl → interact
 
 ## Quick start
@@ -31,6 +32,9 @@ firecrawl search "your query" --sources news --tbs qdr:d -o .firecrawl/news.json
 
 # Programming question: search GitHub issues, merged PRs, READMEs, and docs
 firecrawl search "your query" --categories developer -o .firecrawl/developer.json --json
+
+# Research papers: use the paper index, NOT `search --categories research`
+firecrawl research search-papers "your query" -o .firecrawl/papers.json --json
 ```
 
 ## Developer search
@@ -57,20 +61,52 @@ Each result holds `id`, `type` (`issue`, `pull_request`, `readme`, `doc`),
 `url`, `title`, and `passages`. Read them with
 `jq -r '.results[] | .url, .passages[].text' .firecrawl/developer.json`.
 
+## Paper search
+
+**`--categories research` is not the paper index.** It only narrows ordinary web
+results to research-affiliated websites (a short domain allowlist). For actual
+papers use the `firecrawl research` command group, which searches roughly 43M
+abstracts, around 90% biomedical (PubMed, bioRxiv, medRxiv) plus arXiv.
+
+Reach for it on any biomedical, clinical, or scientific-literature question
+instead of web-searching or scraping PubMed, bioRxiv, medRxiv, or Google
+Scholar by hand:
+
+```bash
+# Find papers by topic -- start here, and run several distinct framings
+firecrawl research search-papers "CRISPR base editing off-target effects" \
+  --limit 20 -o .firecrawl/papers.json --json
+
+# Expand from your strongest hits along the citation graph
+firecrawl research related-papers pmid:40953549 --intent "in vivo delivery" \
+  -o .firecrawl/papers-related.json --json
+
+# Verify a specific claim against the full text before you cite it
+firecrawl research read-paper pmcid:PMC12530322 --question "What was the sample size?" \
+  -o .firecrawl/paper-passages.json --json
+```
+
+Paper ids accept `pmid:`, `pmcid:`, `doi:`, and `arxiv:` forms. `inspect-paper`
+returns canonical metadata for one id. Read hits with
+`jq -r '.results[] | .primaryId, .title' .firecrawl/papers.json`.
+
+See [firecrawl-cli](../firecrawl-cli/SKILL.md) for how paper search fits the
+overall command routing.
+
 ## Options
 
-| Option                                         | Description                                   |
-| ---------------------------------------------- | --------------------------------------------- |
-| `--limit <n>`                                  | Max number of results                         |
-| `--sources <web,images,news>`                  | Source types to search                        |
-| `--categories <github,research,pdf,developer>` | Filter by category                            |
-| `--tbs <qdr:h\|d\|w\|m\|y>`                    | Time-based search filter                      |
-| `--location`                                   | Location for search results                   |
-| `--country <code>`                             | Country code for search                       |
-| `--scrape`                                     | Also scrape full page content for each result |
-| `--scrape-formats`                             | Formats when scraping (default: markdown)     |
-| `-o, --output <path>`                          | Output file path                              |
-| `--json`                                       | Output as JSON                                |
+| Option                                         | Description                                                                                                                                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--limit <n>`                                  | Max number of results                                                                                                                                              |
+| `--sources <web,images,news>`                  | Source types to search                                                                                                                                             |
+| `--categories <github,research,pdf,developer>` | Filter by category. `research` = research-affiliated websites (see [Paper search](#paper-search) for the actual paper index); `developer` = the coding-agent index |
+| `--tbs <qdr:h\|d\|w\|m\|y>`                    | Time-based search filter                                                                                                                                           |
+| `--location`                                   | Location for search results                                                                                                                                        |
+| `--country <code>`                             | Country code for search                                                                                                                                            |
+| `--scrape`                                     | Also scrape full page content for each result                                                                                                                      |
+| `--scrape-formats`                             | Formats when scraping (default: markdown)                                                                                                                          |
+| `-o, --output <path>`                          | Output file path                                                                                                                                                   |
+| `--json`                                       | Output as JSON                                                                                                                                                     |
 
 ## Tips
 

--- a/src/__tests__/cli-argv.test.ts
+++ b/src/__tests__/cli-argv.test.ts
@@ -34,6 +34,50 @@ describe('CLI argv parsing', () => {
     expect(result.stderr).not.toContain('unknown command');
   });
 
+  testWithBuiltCli('lists the research command in root help output', () => {
+    const result = spawnSync(process.execPath, [cliPath, '--help'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/^\s*research\b/m);
+  });
+
+  testWithBuiltCli('parses the research command and shows its help', () => {
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, 'research', '--help'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: firecrawl research');
+    expect(result.stdout).toContain('search-papers');
+    expect(result.stdout).toContain('read-paper');
+    expect(result.stderr).not.toContain('unknown command');
+  });
+
+  testWithBuiltCli(
+    'describes the research index by its real corpus, not just arXiv',
+    () => {
+      const result = spawnSync(process.execPath, [cliPath, '--help'], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(/^\s*research\b/m);
+      // Collapse wrapping so the assertion does not depend on terminal width.
+      const flattened = result.stdout.replace(/\s+/g, ' ');
+      expect(flattened).toContain('PubMed');
+      expect(flattened).toContain('biomedical');
+    }
+  );
+
   testWithBuiltCli(
     'exposes explicit keyless MCP setup and launch flags',
     () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -920,7 +920,7 @@ function createSearchCommand(): Command {
     )
     .option(
       '--categories <categories>',
-      'Comma-separated categories to filter: github, research, pdf, developer (developer searches indexed GitHub issues, merged PRs, READMEs, and docs)'
+      'Comma-separated categories to filter: github, research, pdf, developer (research filters web results to research-affiliated websites -- it is NOT the paper index; for papers use `firecrawl research search-papers`. developer searches indexed GitHub issues, merged PRs, READMEs, and docs)'
     )
     .option(
       '--tbs <value>',
@@ -1101,14 +1101,18 @@ Examples:
  */
 function createResearchCommand(): Command {
   const researchCmd = new Command('research')
-    .description('Research arXiv papers and GitHub history using Firecrawl')
+    .description(
+      "Search Firecrawl's research paper index: ~43M abstracts, around 90% biomedical (PubMed, bioRxiv, medRxiv) plus arXiv. Use this for biomedical, clinical, and scientific literature instead of scraping PubMed, bioRxiv, or Google Scholar by hand. Also searches GitHub issue/PR history."
+    )
     .addHelpText(
       'after',
       `
 Examples:
+  $ firecrawl research search-papers "CRISPR base editing off-target effects" --limit 20
   $ firecrawl research search-papers "diffusion image synthesis" --limit 20
-  $ firecrawl research inspect-paper arxiv:1706.03762
-  $ firecrawl research related-papers arxiv:1706.03762 --intent "efficient transformers"
+  $ firecrawl research inspect-paper pmid:40953549
+  $ firecrawl research related-papers pmcid:PMC12530322 --intent "in vivo delivery"
+  $ firecrawl research read-paper doi:10.1016/j.neunet.2025.108095 --question "What was the sample size?"
   $ firecrawl research read-paper arxiv:1706.03762 --question "What is the attention mechanism?"
   $ firecrawl research search-github "foundationdb queue worker shutdown" --limit 10
 `
@@ -1117,7 +1121,7 @@ Examples:
   researchCmd
     .command('search-papers')
     .description(
-      'Primary entry point for finding arXiv papers by topic. Semantic (HyDE) search over arXiv abstracts; returns ranked papers with arXiv id, title, and abstract. The query should be a natural-language description of what you want. Run several distinct framings of the question rather than one query. Returns up to k results (default 40).'
+      'Primary entry point for finding research papers by topic. Semantic (HyDE) search over ~43M paper abstracts, around 90% biomedical (PubMed, bioRxiv, medRxiv) plus arXiv; returns ranked papers with a source id (pmid:, pmcid:, doi:, or arxiv:), title, and abstract. Use this instead of web-searching or scraping PubMed, bioRxiv, medRxiv, or Google Scholar. The query should be a natural-language description of what you want. Run several distinct framings of the question rather than one query. Returns up to k results (default 40).'
     )
     .argument('<query>', 'Natural-language description of the papers to find')
     .option(
@@ -1132,7 +1136,7 @@ Examples:
     )
     .option(
       '--categories <categories>',
-      'Comma-separated arXiv category filter(s), e.g. cs.LG,cs.IR; all must match'
+      'Comma-separated category filter(s); all must match. Values are arXiv-style taxonomy labels, e.g. cs.LG,cs.IR. PubMed/bioRxiv/medRxiv records do not use that taxonomy, so omit this flag when searching biomedical literature.'
     )
     .option(
       '--from <date>',
@@ -1197,11 +1201,11 @@ Examples:
   researchCmd
     .command('related-papers')
     .description(
-      'Expand from anchor papers you have already found, via the citation graph, ranked and filtered to a natural-language intent. Pass arXiv ids of your strongest hits as seed ids. Modes: similar, citers, references. This reaches relevant papers that plain search misses. A similar call already runs a deep multi-round expansion internally.'
+      'Expand from anchor papers you have already found, via the citation graph, ranked and filtered to a natural-language intent. Pass the ids of your strongest hits as seed ids, in any supported form (pmid:, pmcid:, doi:, arxiv:, or a canonical paperId). Modes: similar, citers, references. This reaches relevant papers that plain search misses. A similar call already runs a deep multi-round expansion internally.'
     )
     .argument(
       '<seedIds...>',
-      'Seed paper ids, e.g. arxiv:1706.03762 2014215642691656232'
+      'Space-separated seed paper ids such as pmid:40953549, pmcid:PMC12530322, doi:10.1016/j.neunet.2025.108095, or arxiv:1706.03762; canonical paperIds (e.g. 2014215642691656232) also work'
     )
     .requiredOption(
       '--intent <text>',


### PR DESCRIPTION
## Why
The CLI's research command group was branded arXiv-only ("Research arXiv papers and GitHub history") while the index it fronts is mostly biomedical (PubMed, bioRxiv, medRxiv). In 8/8 measured agent traces on biomedical tasks, agents read `firecrawl --help`, concluded the command was not relevant, and hand-scraped PubMed instead. The README also taught `firecrawl search --categories research` (a website filter) as the way to "Find research papers" and never mentioned `firecrawl research` at all.

## Summary
- Root `--help` line and all five research subcommand descriptions now name the real corpus; multi-source id examples (`pmid:`, `pmcid:`, `doi:`) used throughout
- `search --categories` help disambiguates `research` (website filter) from `firecrawl research` (paper index); the wire value `research` is untouched
- README: wrong worked example fixed; a `### research` command section added (it was the only command without one); tagline updated
- Skills: `firecrawl-search` SKILL gains a Paper search section (parity with its Developer search section); `firecrawl-cli` routing table gains research rows
- 3 new regression tests guard research's help visibility (parity with the existing developer guards)
- package.json → 1.20.0; homebrew/nfpm descriptions synced

## Test Plan
- `pnpm test` 422/422 (incl. 3 new argv guards), `pnpm run build` + `type-check` + `format:check` clean
- Rendered `firecrawl --help` / `firecrawl research --help` verified from the built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies and correctly brands the research paper index across the CLI, docs, and skills so users run `firecrawl research` for papers (PubMed, bioRxiv, medRxiv, arXiv) instead of the web category filter or hand-scraping. This fixes arXiv-only wording that led users to skip the paper index.

- Root `--help` and all `research` subcommands name the real corpus and show `pmid:`, `pmcid:`, and `doi:` examples; `search-papers`/`related-papers` docs note arXiv taxonomy limits and accept multi-source ids.
- Disambiguated `search --categories research` (website filter) from the paper index; help now points to `firecrawl research search-papers` (wire value unchanged).
- README and skills: added a `research` section, corrected examples, routed paper workflows through `research`, and added a Paper search section to `firecrawl-search`.
- Install and run commands now use `@latest` instead of pinned versions; sample `--status` reflects `v1.20.0`.
- Added 3 CLI argv tests guarding help visibility and biomedical wording; updated packaging descriptions and keywords; bumped `firecrawl-cli` to `1.20.0`.

<sup>Written for commit ab0f63a1c837b9cd407e2072121f1636590f3f42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

