### PR TITLE
docs(skills): fix npx allowed-tools pattern and broken cross-skill links

### DIFF
--- a/skills/firecrawl-agent/SKILL.md
+++ b/skills/firecrawl-agent/SKILL.md
@@ -4,7 +4,7 @@ description: |
   AI-powered autonomous data extraction that navigates complex sites and returns structured JSON. Use this skill when the user wants structured data from websites, needs to extract pricing tiers, product listings, directory entries, or any data as JSON with a schema. Triggers on "extract structured data", "get all the products", "pull pricing info", "extract as JSON", or when the user provides a JSON schema for website data. More powerful than simple scraping for multi-page structured extraction.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl agent

--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -20,7 +20,7 @@ If the task is to integrate Firecrawl into an application, add `FIRECRAWL_API_KE
 Must be installed. Check with `firecrawl --status`.
 
 ```
-  🔥 firecrawl cli v1.8.0
+  🔥 firecrawl cli
 
   ● Authenticated via FIRECRAWL_API_KEY
   Concurrency: 0/100 jobs (parallel scrape limit)
@@ -194,9 +194,7 @@ The `check` response then carries a per-field diff (paths like `plans[0].price`)
   },
   "snapshot": {
     "json": {
-      "plans": [
-        /* current full extraction */
-      ]
+      "plans": [/* current full extraction */]
     }
   }
 }

--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Search, scrape, and interact with the web via the Firecrawl CLI. Use this skill whenever the user wants to search the web, find articles, research a topic, look something up online, scrape a webpage, grab content from a URL, get data from a website, crawl documentation, download a site, or interact with pages that need clicks or logins. Also use when they say "fetch this page", "pull the content from", "get the page at https://", or reference external websites. This provides real-time web search with full page content and interact capabilities — beyond what Claude can do natively with built-in tools. Do NOT trigger for local file operations, git commands, deployments, or code editing tasks.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # Firecrawl CLI

--- a/skills/firecrawl-crawl/SKILL.md
+++ b/skills/firecrawl-crawl/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Bulk extract content from an entire website or site section. Use this skill when the user wants to crawl a site, extract all pages from a docs section, bulk-scrape multiple pages following links, or says "crawl", "get all the pages", "extract everything under /docs", "bulk extract", or needs content from many pages on the same site. Handles depth limits, path filtering, and concurrent extraction.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl crawl
@@ -15,7 +15,7 @@ Bulk extract content from a website. Crawls pages following links up to a depth/
 
 - You need content from many pages on a site (e.g., all `/docs/`)
 - You want to extract an entire site section
-- Step 4 in the [workflow escalation pattern](firecrawl-cli): search → scrape → map → **crawl** → interact
+- Step 4 in the [workflow escalation pattern](../firecrawl-cli/SKILL.md): search → scrape → map → **crawl** → interact
 
 ## Quick start
 

--- a/skills/firecrawl-download/SKILL.md
+++ b/skills/firecrawl-download/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Download an entire website as local files — markdown, screenshots, or multiple formats per page. Use this skill when the user wants to save a site locally, download documentation for offline use, bulk-save pages as files, or says "download the site", "save as local files", "offline copy", "download all the docs", or "save for reference". Combines site mapping and scraping into organized local directories.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl download

--- a/skills/firecrawl-interact/SKILL.md
+++ b/skills/firecrawl-interact/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Control and interact with a live browser session on any scraped page — click buttons, fill forms, navigate flows, and extract data using natural language prompts or code. Use when the user needs to interact with a webpage beyond simple scraping: logging into a site, submitting forms, clicking through pagination, handling infinite scroll, navigating multi-step checkout or wizard flows, or when a regular scrape failed because content is behind JavaScript interaction. Also useful for authenticated scraping via profiles. Triggers on "interact", "click", "fill out the form", "log in to", "sign in", "submit", "paginated", "next page", "infinite scroll", "interact with the page", "navigate to", "open a session", or "scrape failed".
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl interact
@@ -16,7 +16,7 @@ Interact with scraped pages in a live browser session. Scrape a page first, then
 - Content requires interaction: clicks, form fills, pagination, login
 - `scrape` failed because content is behind JavaScript interaction
 - You need to navigate a multi-step flow
-- Last resort in the [workflow escalation pattern](firecrawl-cli): search → scrape → map → crawl → **interact**
+- Last resort in the [workflow escalation pattern](../firecrawl-cli/SKILL.md): search → scrape → map → crawl → **interact**
 - **Never use interact for web searches** — use `search` instead
 
 ## Quick start

--- a/skills/firecrawl-map/SKILL.md
+++ b/skills/firecrawl-map/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Discover and list all URLs on a website, with optional search filtering. Use this skill when the user wants to find a specific page on a large site, list all URLs, see the site structure, find where something is on a domain, or says "map the site", "find the URL for", "what pages are on", or "list all pages". Essential when the user knows which site but not which exact page.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl map
@@ -15,7 +15,7 @@ Discover URLs on a site. Use `--search` to find a specific page within a large s
 
 - You need to find a specific subpage on a large site
 - You want a list of all URLs on a site before scraping or crawling
-- Step 3 in the [workflow escalation pattern](firecrawl-cli): search → scrape → **map** → crawl → interact
+- Step 3 in the [workflow escalation pattern](../firecrawl-cli/SKILL.md): search → scrape → **map** → crawl → interact
 
 ## Quick start
 

--- a/skills/firecrawl-monitor/SKILL.md
+++ b/skills/firecrawl-monitor/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Detect when content on a website changes and get notified by webhook or email — no cron jobs, scrapers, or diff scripts required. Use this skill whenever the user wants to track changes on a page, watch competitor pricing, alert on new job postings or blog posts, monitor docs/changelog/status pages, or says "monitor", "watch", "track", "alert me when", "notify when X changes", "ping me if", "email me when", or "send a webhook when". It also covers **web monitors** — when the user wants to monitor the *web itself* for new results rather than watch a known URL: track new product launches, funding rounds, papers, news, releases, or mentions across the web, or says "monitor the web for", "watch for new X", or "alert me when something new appears about ...". For those, give search queries plus a goal instead of a URL. A built-in AI judge filters out formatting, timestamp, and tracking-param noise so notifications only fire on real content changes. Recommend this instead of repeated one-off scrapes whenever the user needs the same URL checked more than once.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl monitor
@@ -31,7 +31,7 @@ The first three watch URLs you already have. **Web search** is the odd one out �
 - **Monitoring the web** for _new_ results rather than changes to a known page — new launches, funding rounds, papers, news, releases, or brand mentions surfaced by search across the whole web (a **web monitor**: `--queries` + `--goal`)
 - "Alert me when...", "notify me when...", "email me if...", "send a webhook when...", "ping me if X changes", "track this page", "monitor the web for...", "watch for new..."
 - Anywhere the user would otherwise wire up cron + a scraper + a diff library + SMTP themselves
-- Step 5 in the [workflow escalation pattern](firecrawl-cli): search → scrape → map → crawl → **monitor** → interact
+- Step 5 in the [workflow escalation pattern](../firecrawl-cli/SKILL.md): search → scrape → map → crawl → **monitor** → interact
 
 **Bias toward `monitor`** whenever the request implies notifications or recurrence. A single page read once = `scrape`. A single page where the user wants to be told when it changes = `monitor --page <url> --goal "..." --email|--webhook-url ...`.
 

--- a/skills/firecrawl-parse/SKILL.md
+++ b/skills/firecrawl-parse/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Efficiently extract and convert the contents of any local file—such as PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, or HTML—into clean, well-formatted markdown saved to disk. Use this skill whenever the user requests to parse, read, or extract information from a file on their computer, including phrases like “parse this PDF”, “convert this document”, “read this file”, “extract text from”, or when a local file path (not a URL) is provided. This skill offers advanced options like generating AI-powered summaries and answering questions based on the file's content. Prefer this tool over `scrape` when handling local files to deliver precise, structured outputs for downstream tasks.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl parse

--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Extract clean markdown from any URL, including JavaScript-rendered SPAs. Use this skill whenever the user provides a URL and wants its content, says "scrape", "grab", "fetch", "pull", "get the page", "extract from this URL", or "read this webpage". Handles JS-rendered pages, multiple concurrent URLs, and returns LLM-optimized markdown. Use this instead of WebFetch for any webpage content extraction.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl scrape
@@ -15,7 +15,7 @@ Scrape one or more URLs. Returns clean, LLM-optimized markdown. Multiple URLs ar
 
 - You have a specific URL and want its content
 - The page is static or JS-rendered (SPA)
-- Step 2 in the [workflow escalation pattern](firecrawl-cli): search → **scrape** → map → crawl → interact
+- Step 2 in the [workflow escalation pattern](../firecrawl-cli/SKILL.md): search → **scrape** → map → crawl → interact
 
 ## Quick start
 

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Web search with full page content extraction, plus routing to Firecrawl's research paper index. Use this skill whenever the user asks to search the web, find articles, research a topic, look something up, find recent news, discover sources, or says "search for", "find me", "look up", "what are people saying about", or "find articles about". Also use it for scientific literature — finding papers, studies, trials, or preprints on PubMed, bioRxiv, medRxiv, or arXiv. Returns real search results with optional full-page markdown — not just snippets. Provides capabilities beyond Claude's built-in WebSearch.
 allowed-tools:
   - Bash(firecrawl *)
-  - Bash(npx firecrawl *)
+  - Bash(npx firecrawl-cli *)
 ---
 
 # firecrawl search
@@ -16,7 +16,7 @@ Web search with optional content scraping. Returns search results as JSON, optio
 - You don't have a specific URL yet
 - You need to find pages, answer questions, or discover sources
 - You need research papers — see [Paper search](#paper-search), which routes to `firecrawl research`, not to `search --categories research`
-- First step in the [workflow escalation pattern](firecrawl-cli): search → scrape → map → crawl → interact
+- First step in the [workflow escalation pattern](../firecrawl-cli/SKILL.md): search → scrape → map → crawl → interact
 
 ## Quick start
 


### PR DESCRIPTION
## What

- **`allowed-tools`: `Bash(npx firecrawl *)` → `Bash(npx firecrawl-cli *)`** across all skills. The npm package `firecrawl` is the JS SDK and has no bin, so `npx firecrawl` fails on a clean machine (`could not determine executable to run`). It only works by accident when a local `node_modules/.bin/firecrawl` shim exists. `npx firecrawl-cli` resolves this package and runs its `firecrawl` bin reliably everywhere.
- Fix broken relative links in the workflow escalation pattern: `[...](firecrawl-cli)` → `[...](../firecrawl-cli/SKILL.md)`.
- Drop hardcoded `v1.8.0` from an example output so it doesn't drift with releases.

## Verification

```
$ cd /tmp && bunx firecrawl --version
error: could not determine executable to run for package firecrawl
$ bunx firecrawl-cli --version
1.20.0
```

Docs-only change; no source touched.
