### PR TITLE
docs(skills): fix behavior claims that don't match the CLI

### DIFF
--- a/skills/firecrawl-agent/SKILL.md
+++ b/skills/firecrawl-agent/SKILL.md
@@ -30,18 +30,37 @@ firecrawl agent "extract products" --schema '{"type":"object","properties":{"nam
 firecrawl agent "get feature list" --urls "<url>" --wait -o .firecrawl/features.json
 ```
 
+## Job IDs
+
+Without `--wait`, the command returns a job ID. A UUID positional argument is auto-detected as a status check:
+
+```bash
+# Check once (equivalent to adding --status)
+firecrawl agent "<job-id>"
+
+# Wait on an existing job, polling every 10 seconds for up to 5 minutes
+firecrawl agent "<job-id>" --wait --poll-interval 10 --timeout 300
+
+# Cancel an active job
+firecrawl agent "<job-id>" --cancel
+```
+
 ## Options
 
-| Option                 | Description                               |
-| ---------------------- | ----------------------------------------- |
-| `--urls <urls>`        | Starting URLs for the agent               |
-| `--model <model>`      | Model to use: spark-1-mini or spark-1-pro |
-| `--schema <json>`      | JSON schema for structured output         |
-| `--schema-file <path>` | Path to JSON schema file                  |
-| `--max-credits <n>`    | Credit limit for this agent run           |
-| `--wait`               | Wait for agent to complete                |
-| `--pretty`             | Pretty print JSON output                  |
-| `-o, --output <path>`  | Output file path                          |
+| Option                      | Description                                         |
+| --------------------------- | --------------------------------------------------- |
+| `--urls <urls>`             | Starting URLs for the agent                         |
+| `--model <model>`           | Model to use: spark-1-mini or spark-1-pro           |
+| `--schema <json>`           | JSON schema for structured output                   |
+| `--schema-file <path>`      | Path to JSON schema file                            |
+| `--max-credits <n>`         | Credit limit for this agent run                     |
+| `--status`                  | Check a job ID's status                             |
+| `--cancel`                  | Cancel an active job ID                             |
+| `--wait`                    | Wait for agent to complete                          |
+| `--poll-interval <seconds>` | Polling interval while waiting (default: 5 seconds) |
+| `--timeout <seconds>`       | Stop waiting after this duration (default: none)    |
+| `--pretty`                  | Pretty print JSON output                            |
+| `-o, --output <path>`       | Output file path                                    |
 
 ## Tips
 

--- a/skills/firecrawl-agent/SKILL.md
+++ b/skills/firecrawl-agent/SKILL.md
@@ -64,7 +64,7 @@ firecrawl agent "<job-id>" --cancel
 
 ## Tips
 
-- Always use `--wait` to get results inline. Without it, returns a job ID.
+- Use `--wait` for inline results; without it you get a job ID (see [Job IDs](#job-ids)).
 - Use `--schema` for predictable, structured output — otherwise the agent returns freeform data.
 - Agent runs consume more credits than simple scrapes. Use `--max-credits` to cap spending.
 - For simple single-page extraction, prefer `scrape` — it's faster and cheaper.

--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -194,9 +194,7 @@ The `check` response then carries a per-field diff (paths like `plans[0].price`)
   },
   "snapshot": {
     "json": {
-      "plans": [
-        /* current full extraction */
-      ]
+      "plans": [/* current full extraction */]
     }
   }
 }
@@ -269,7 +267,8 @@ jq -r '.data.web[] | "\(.title): \(.url)"' .firecrawl/search.json
 Search costs 2 credits per call. **After you finish using a search result**, send structured feedback in the background. The first feedback per search id refunds 1 credit and feeds search-quality improvements.
 
 ```bash
-SEARCH_ID=$(jq -r '.id' .firecrawl/search-react-hooks.json)
+# Guard: zero-result searches write no output file, so verify before reading the id
+SEARCH_ID=$(jq -er 'select(any(.data[]; length > 0)) | .id' .firecrawl/search-react-hooks.json)
 
 firecrawl search-feedback "$SEARCH_ID" \
   --rating good \

--- a/skills/firecrawl-download/SKILL.md
+++ b/skills/firecrawl-download/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
 
 > **Experimental.** Convenience command that combines `map` + `scrape` to save an entire site as local files.
 
-Maps the site first to discover pages, then scrapes each one into nested directories under `.firecrawl/`. All scrape options work with download. Always pass `-y` to skip the confirmation prompt.
+Maps the site origin first to discover pages, then scrapes each one into nested directories under `.firecrawl/`. Use `--include-paths` to scope a non-root URL to one section. Always pass `-y` to skip the confirmation prompt.
 
 ## When to use
 
@@ -33,10 +33,10 @@ firecrawl download https://docs.example.com --format markdown,links --screenshot
 # Creates per page: index.md + links.txt + screenshot.png
 
 # Filter to specific sections
-firecrawl download https://docs.example.com --include-paths "/features,/sdks"
+firecrawl download https://docs.example.com --include-paths "/features,/sdks" -y
 
 # Skip translations
-firecrawl download https://docs.example.com --exclude-paths "/zh,/ja,/fr,/es,/pt-BR"
+firecrawl download https://docs.example.com --exclude-paths "/zh,/ja,/fr,/es,/pt-BR" -y
 
 # Full combo
 firecrawl download https://docs.example.com \
@@ -58,7 +58,9 @@ firecrawl download https://docs.example.com \
 | `--allow-subdomains`      | Include subdomain pages                                  |
 | `-y`                      | Skip confirmation prompt (always use in automated flows) |
 
-## Scrape options (all work with download)
+## Supported scrape options
+
+Only the options listed below are supported:
 
 `-f <formats>`, `-H`, `-S`, `--screenshot`, `--full-page-screenshot`, `--only-main-content`, `--include-tags`, `--exclude-tags`, `--wait-for`, `--max-age`, `--country`, `--languages`
 

--- a/skills/firecrawl-download/SKILL.md
+++ b/skills/firecrawl-download/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools:
   - Bash(npx firecrawl *)
 ---
 
-# firecrawl download
+# firecrawl download (invoked as `firecrawl x download`)
 
 > **Experimental.** Convenience command that combines `map` + `scrape` to save an entire site as local files.
 
@@ -22,24 +22,24 @@ Maps the site origin first to discover pages, then scrapes each one into nested 
 ## Quick start
 
 ```bash
-# Interactive wizard (picks format, screenshots, paths for you)
-firecrawl download https://docs.example.com
+# Interactive wizard (humans at a TTY only — agents must pass -y or the command blocks on a prompt)
+firecrawl x download https://docs.example.com
 
 # With screenshots
-firecrawl download https://docs.example.com --screenshot --limit 20 -y
+firecrawl x download https://docs.example.com --screenshot --limit 20 -y
 
 # Multiple formats (each saved as its own file per page)
-firecrawl download https://docs.example.com --format markdown,links --screenshot --limit 20 -y
+firecrawl x download https://docs.example.com --format markdown,links --screenshot --limit 20 -y
 # Creates per page: index.md + links.txt + screenshot.png
 
 # Filter to specific sections
-firecrawl download https://docs.example.com --include-paths "/features,/sdks" -y
+firecrawl x download https://docs.example.com --include-paths "/features,/sdks" -y
 
 # Skip translations
-firecrawl download https://docs.example.com --exclude-paths "/zh,/ja,/fr,/es,/pt-BR" -y
+firecrawl x download https://docs.example.com --exclude-paths "/zh,/ja,/fr,/es,/pt-BR" -y
 
 # Full combo
-firecrawl download https://docs.example.com \
+firecrawl x download https://docs.example.com \
   --include-paths "/features,/sdks" \
   --exclude-paths "/zh,/ja" \
   --only-main-content \
@@ -62,7 +62,7 @@ firecrawl download https://docs.example.com \
 
 Only the options listed below are supported:
 
-`-f <formats>`, `-H`, `-S`, `--screenshot`, `--full-page-screenshot`, `--only-main-content`, `--include-tags`, `--exclude-tags`, `--wait-for`, `--max-age`, `--country`, `--languages`
+`-f <formats>`, `-H`, `-S`, `--lockdown`, `--screenshot`, `--full-page-screenshot`, `--only-main-content`, `--include-tags`, `--exclude-tags`, `--wait-for`, `--max-age`, `--country`, `--languages`
 
 ## See also
 

--- a/skills/firecrawl-interact/SKILL.md
+++ b/skills/firecrawl-interact/SKILL.md
@@ -25,14 +25,17 @@ Interact with scraped pages in a live browser session. Scrape a page first, then
 # 1. Scrape a page (scrape ID is saved automatically)
 firecrawl scrape "<url>"
 
-# 2. Interact with the page using natural language
-firecrawl interact --prompt "Click the login button"
-firecrawl interact --prompt "Fill in the email field with test@example.com"
-firecrawl interact --prompt "Extract the pricing table"
+# 2. Interact with the page using a positional prompt
+firecrawl interact "Click the login button"
+firecrawl interact "Fill in the email field with test@example.com"
+firecrawl interact "Extract the pricing table"
+
+# A UUID first argument is auto-detected as the scrape ID
+firecrawl interact "<scrape-id>" "Extract the pricing table"
 
 # 3. Or use code for precise control
-firecrawl interact --code "agent-browser click @e5" --language bash
-firecrawl interact --code "agent-browser snapshot -i" --language bash
+firecrawl interact --code "click @e5" --bash
+firecrawl interact --code "snapshot -i" --bash
 
 # 4. Stop the session when done
 firecrawl interact stop
@@ -72,7 +75,7 @@ firecrawl scrape "https://app.example.com" --profile my-app --no-save-changes
 ## Tips
 
 - Always scrape first — `interact` requires a scrape ID from a previous `firecrawl scrape` call
-- The scrape ID is saved automatically, so you don't need `--scrape-id` for subsequent interact calls
+- The scrape ID is saved automatically, so you don't need `--scrape-id` for subsequent interact calls. Saved sessions may expire after about 10 minutes; re-scrape if the CLI warns that the session is stale
 - Use `firecrawl interact stop` to free resources when done
 - For parallel work, scrape multiple pages and interact with each using `--scrape-id`
 

--- a/skills/firecrawl-interact/SKILL.md
+++ b/skills/firecrawl-interact/SKILL.md
@@ -43,14 +43,14 @@ firecrawl interact stop
 
 ## Options
 
-| Option                | Description                                       |
-| --------------------- | ------------------------------------------------- |
-| `--prompt <text>`     | Natural language instruction (use this OR --code) |
-| `--code <code>`       | Code to execute in the browser session            |
-| `--language <lang>`   | Language for code: bash, python, node             |
-| `--timeout <seconds>` | Execution timeout (default: 30, max: 300)         |
-| `--scrape-id <id>`    | Target a specific scrape (default: last scrape)   |
-| `-o, --output <path>` | Output file path                                  |
+| Option                           | Description                                       |
+| -------------------------------- | ------------------------------------------------- |
+| `--prompt <text>`                | Natural language instruction (use this OR --code) |
+| `--code <code>`                  | Code to execute in the browser session            |
+| `--node` / `--python` / `--bash` | Language for `--code` (default: node)             |
+| `--timeout <seconds>`            | Execution timeout (default: 30, max: 300)         |
+| `--scrape-id <id>`               | Target a specific scrape (default: last scrape)   |
+| `-o, --output <path>`            | Output file path                                  |
 
 ## Profiles
 

--- a/skills/firecrawl-parse/SKILL.md
+++ b/skills/firecrawl-parse/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
 
 # firecrawl parse
 
-Turn a local document into clean markdown on disk. Supports **PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, HTML/HTM/XHTML**.
+Turn a local document into clean markdown on disk. Supports **PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, HTML/HTM**.
 
 ## When to use
 
@@ -39,14 +39,14 @@ Then `head`, `grep`, `rg` etc., or incrementally read the file - don't load the 
 
 ## Options
 
-| Option                 | Description                             |
-| ---------------------- | --------------------------------------- |
-| `-S, --summary`        | AI-generated summary                    |
-| `-Q, --query <prompt>` | Ask a question about the parsed content |
-| `-o, --output <path>`  | Output file path — **always use this**  |
-| `-f, --format <fmt>`   | `markdown` (default), `html`, `summary` |
-| `--timeout <ms>`       | Timeout for the parse job               |
-| `--timing`             | Show request duration                   |
+| Option                   | Description                                                                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `-S, --summary`          | AI-generated summary                                                                                                             |
+| `-Q, --query <prompt>`   | Ask a question about the parsed content                                                                                          |
+| `-o, --output <path>`    | Output file path — **always use this**                                                                                           |
+| `-f, --format <formats>` | Comma-separated: `markdown`, `html`, `rawHtml`, `links`, `images`, `summary`, `json`, `attributes`. Multiple formats output JSON |
+| `--timeout <ms>`         | Timeout for the parse job                                                                                                        |
+| `--timing`               | Show request duration                                                                                                            |
 
 ## Tips
 

--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -29,7 +29,7 @@ firecrawl scrape "<url>" --only-main-content -o .firecrawl/page.md
 # Wait for JS to render, then scrape
 firecrawl scrape "<url>" --wait-for 3000 -o .firecrawl/page.md
 
-# Multiple URLs (each saved to .firecrawl/)
+# Multiple URLs (markdown only; each saved to .firecrawl/; -o is ignored)
 firecrawl scrape https://example.com https://example.com/blog https://example.com/docs
 
 # Get markdown and links together
@@ -41,23 +41,23 @@ firecrawl scrape "https://example.com/pricing" --query "What is the enterprise p
 
 ## Options
 
-| Option                   | Description                                                      |
-| ------------------------ | ---------------------------------------------------------------- |
-| `-f, --format <formats>` | Output formats: markdown, html, rawHtml, links, screenshot, json |
-| `-Q, --query <prompt>`   | Ask a question about the page content (5 credits)                |
-| `-H`                     | Include HTTP headers in output                                   |
-| `--only-main-content`    | Strip nav, footer, sidebar — main content only                   |
-| `--wait-for <ms>`        | Wait for JS rendering before scraping                            |
-| `--include-tags <tags>`  | Only include these HTML tags                                     |
-| `--exclude-tags <tags>`  | Exclude these HTML tags                                          |
-| `--redact-pii`           | Redact personally identifiable information from output           |
-| `-o, --output <path>`    | Output file path                                                 |
+| Option                   | Description                                                                                                             |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `-f, --format <formats>` | Output formats: markdown, html, rawHtml, links, images, screenshot, summary, changeTracking, json, attributes, branding |
+| `-Q, --query <prompt>`   | Ask a question about the page content (5 credits)                                                                       |
+| `-H`                     | Include HTTP headers in output                                                                                          |
+| `--only-main-content`    | Strip nav, footer, sidebar — main content only                                                                          |
+| `--wait-for <ms>`        | Wait for JS rendering before scraping                                                                                   |
+| `--include-tags <tags>`  | Only include these HTML tags                                                                                            |
+| `--exclude-tags <tags>`  | Exclude these HTML tags                                                                                                 |
+| `--redact-pii`           | Redact personally identifiable information from output                                                                  |
+| `-o, --output <path>`    | Output file path                                                                                                        |
 
 ## Tips
 
 - **Prefer plain scrape over `--query`.** Scrape to a file, then use `grep`, `head`, or read the markdown directly — you can search and reason over the full content yourself. Use `--query` only when you want a single targeted answer without saving the page (costs 5 extra credits).
 - **Try scrape before interact.** Scrape handles static pages and JS-rendered SPAs. Only escalate to `interact` when you need interaction (clicks, form fills, pagination).
-- Multiple URLs are scraped concurrently — check `firecrawl --status` for your concurrency limit.
+- Multiple URLs are scraped concurrently — check `firecrawl --status` for your concurrency limit. This mode only saves usable markdown; other formats are JSON-stringified into `.md` files, and `-o` is ignored.
 - Single format outputs raw content. Multiple formats (e.g., `--format markdown,links`) output JSON.
 - Always quote URLs — shell interprets `?` and `&` as special characters.
 - Naming convention: `.firecrawl/{site}-{path}.md`

--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -45,7 +45,7 @@ firecrawl scrape "https://example.com/pricing" --query "What is the enterprise p
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | `-f, --format <formats>` | Output formats: markdown, html, rawHtml, links, images, screenshot, summary, changeTracking, json, attributes, branding |
 | `-Q, --query <prompt>`   | Ask a question about the page content (5 credits)                                                                       |
-| `-H`                     | Include HTTP headers in output                                                                                          |
+| `-H`                     | Output raw HTML (shortcut for `--format html`)                                                                          |
 | `--only-main-content`    | Strip nav, footer, sidebar — main content only                                                                          |
 | `--wait-for <ms>`        | Wait for JS rendering before scraping                                                                                   |
 | `--include-tags <tags>`  | Only include these HTML tags                                                                                            |
@@ -57,7 +57,7 @@ firecrawl scrape "https://example.com/pricing" --query "What is the enterprise p
 
 - **Prefer plain scrape over `--query`.** Scrape to a file, then use `grep`, `head`, or read the markdown directly — you can search and reason over the full content yourself. Use `--query` only when you want a single targeted answer without saving the page (costs 5 extra credits).
 - **Try scrape before interact.** Scrape handles static pages and JS-rendered SPAs. Only escalate to `interact` when you need interaction (clicks, form fills, pagination).
-- Multiple URLs are scraped concurrently — check `firecrawl --status` for your concurrency limit. This mode only saves markdown; if markdown isn't requested, the whole response is JSON-stringified into the `.md` file (other formats are otherwise dropped), and `-o` is ignored.
+- Multiple URLs are scraped concurrently — check `firecrawl --status` for your concurrency limit. This mode saves markdown only and ignores `-o`; other requested formats are dropped. If markdown wasn't requested, the whole JSON response is written into the `.md` file.
 - Single format outputs raw content. Multiple formats (e.g., `--format markdown,links`) output JSON.
 - Always quote URLs — shell interprets `?` and `&` as special characters.
 - Naming convention: `.firecrawl/{site}-{path}.md`

--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -57,7 +57,7 @@ firecrawl scrape "https://example.com/pricing" --query "What is the enterprise p
 
 - **Prefer plain scrape over `--query`.** Scrape to a file, then use `grep`, `head`, or read the markdown directly — you can search and reason over the full content yourself. Use `--query` only when you want a single targeted answer without saving the page (costs 5 extra credits).
 - **Try scrape before interact.** Scrape handles static pages and JS-rendered SPAs. Only escalate to `interact` when you need interaction (clicks, form fills, pagination).
-- Multiple URLs are scraped concurrently — check `firecrawl --status` for your concurrency limit. This mode only saves usable markdown; other formats are JSON-stringified into `.md` files, and `-o` is ignored.
+- Multiple URLs are scraped concurrently — check `firecrawl --status` for your concurrency limit. This mode only saves markdown; if markdown isn't requested, the whole response is JSON-stringified into the `.md` file (other formats are otherwise dropped), and `-o` is ignored.
 - Single format outputs raw content. Multiple formats (e.g., `--format markdown,links`) output JSON.
 - Always quote URLs — shell interprets `?` and `&` as special characters.
 - Naming convention: `.firecrawl/{site}-{path}.md`

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -135,13 +135,13 @@ Search costs 2 credits. After you've actually used the results (or decided they 
 - **Idempotent:** re-submitting for the same search id returns success but no extra refund.
 - **`--silent &`** is the right pattern — exit code 0 even on failure, so a rejected/expired call never crashes your pipeline.
 
-Verify the search returned results before reading its `id`. Zero-result searches do not write the output file, so never send feedback from a missing or stale file.
+Verify the search returned results before reading its `id`. Zero-result searches write no output file, so the file may be missing — or left over from an earlier search. Only send feedback when this guard succeeds:
 
 ```bash
 SEARCH_ID=$(jq -er 'select(any(.data[]; length > 0)) | .id' .firecrawl/search-react-hooks.json)
 ```
 
-Then send feedback. Pick the rating that matches what actually happened:
+If the guard fails (non-zero exit: missing file or zero results), skip feedback. Otherwise pick the rating that matches what actually happened:
 
 ```bash
 # Results were useful, with notes on what was still missing

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -135,10 +135,10 @@ Search costs 2 credits. After you've actually used the results (or decided they 
 - **Idempotent:** re-submitting for the same search id returns success but no extra refund.
 - **`--silent &`** is the right pattern — exit code 0 even on failure, so a rejected/expired call never crashes your pipeline.
 
-Read the search response's `id`:
+Verify the search returned results before reading its `id`. Zero-result searches do not write the output file, so never send feedback from a missing or stale file.
 
 ```bash
-SEARCH_ID=$(jq -r '.id' .firecrawl/search-react-hooks.json)
+SEARCH_ID=$(jq -er 'select(any(.data[]; length > 0)) | .id' .firecrawl/search-react-hooks.json)
 ```
 
 Then send feedback. Pick the rating that matches what actually happened:


### PR DESCRIPTION
Docs-only. A skill-vs-`src/` consistency audit found SKILL.md claims that don't match what the CLI actually does. Since skills are agent-consumed, each wrong claim turns into a failing command or a silent wrong result. Every fix below was verified against `src/`.

## Wrong flags / commands
- **scrape**: `-H` documented as "include HTTP headers" — it's actually `--html` (raw HTML shortcut)
- **interact**: table documented a nonexistent `--language <lang>`; the real flags are `--node`/`--python`/`--bash`. Examples also used `--prompt` where the CLI takes a positional prompt
- **download**: examples invoked `firecrawl download`, which doesn't exist — the command is only registered as `firecrawl x download`

## Wrong or incomplete behavior claims
- **download**: removed the false "All scrape options work with download" (only a subset exists); added the missing `--lockdown` to that list; noted mapping starts from the site origin; added `-y` to examples that otherwise block on a confirm prompt (agents have no TTY)
- **parse**: removed unsupported XHTML; corrected `-f/--format` (comma-separated, 8 values, multi-format → JSON)
- **scrape**: completed the `--format` list (11 values); documented that multi-URL mode saves markdown only and ignores `-o`
- **search**: zero-result searches write no output file — added a guarded `jq -er` recipe before the feedback flow (mirrored in the cli skill so the two don't drift)
- **interact**: documented UUID auto-detection and the ~10-minute scrape-session staleness warning
- **agent**: documented the job-ID flow (`--status`, `--cancel`, `--poll-interval` default 5s, `--timeout` default none)

Each claim was independently reviewed against `src/` (file/line evidence in the commit messages).
