### PR TITLE
docs(skills): restore agent-browser prefix in interact bash examples

### DIFF
--- a/skills/firecrawl-interact/SKILL.md
+++ b/skills/firecrawl-interact/SKILL.md
@@ -34,8 +34,8 @@ firecrawl interact "Extract the pricing table"
 firecrawl interact "<scrape-id>" "Extract the pricing table"
 
 # 3. Or use code for precise control
-firecrawl interact --code "click @e5" --bash
-firecrawl interact --code "snapshot -i" --bash
+firecrawl interact --code "agent-browser click @e5" --bash
+firecrawl interact --code "agent-browser snapshot -i" --bash
 
 # 4. Stop the session when done
 firecrawl interact stop


### PR DESCRIPTION
Follow-up to #193, addressing post-merge review feedback

`interact` sends `--code` literally to the API with no client-side prefixing (`src/commands/interact.ts:82-98`), and the server-side bash environment requires invoking `agent-browser` explicitly. #191/#193 correctly removed the nonexistent `--language` flag but wrongly dropped the `agent-browser` prefix — an over-generalization from `browser execute`'s auto-prefix logic (`src/index.ts:1851-1859`), which never runs for `interact`.

Note for maintainers: the `interact` help text shows `firecrawl interact -c "snapshot" --bash` without the prefix (`src/index.ts:~1993`) — if the prefix is required, that example may warrant the same fix in a code PR.
