### PR TITLE
release: 1.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website, and search a ~43M-abstract research paper index (PubMed, bioRxiv, medRxiv, arXiv), directly from your terminal.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Version bump for the launch release.

Included since 1.20.0:
- #194 — developer search passages are server-shaped: trust `passage_budget_applied` responses (no local cut), keep the 1,200-char legacy cut only for older servers. The `--passage-budget` flag was removed before ever shipping in a release, per the no-public-knobs decision.

Publishing: merging this triggers the publish workflow (push touching package.json).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `firecrawl-cli` 1.21.0. Developer search passages are now shaped server-side: the CLI trusts `passage_budget_applied` and only applies a 1,200-char legacy cut when talking to older servers. Removes the unreleased `--passage-budget` flag to align with the no-public-knobs policy.

- Migration: if any internal scripts referenced `--passage-budget`, remove it (the flag never shipped).
- Rollout: merging triggers the publish workflow via the `package.json` version bump.

<sup>Written for commit 4383555024e137c5b0dc825528263302672b389e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

