### PR TITLE
fix: derive artifact kind from the id prefix

### DIFF
--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -30,7 +30,12 @@ function fmtDeveloper(
 
   return results
     .map((item) => {
-      const kind = item.type ? ` (${item.type})` : '';
+      // The wire carries no type field; the artifact kind is the id prefix
+      // (doc:, issue:, pull_request:, readme:).
+      const prefix = (item.id ?? '').split(':', 1)[0];
+      const kind = ['doc', 'issue', 'pull_request', 'readme'].includes(prefix)
+        ? ` (${prefix})`
+        : '';
       const lines = [
         `## [${item.id ?? '?'}]${kind} ${item.title ?? '(untitled)'}`,
       ];


### PR DESCRIPTION
The wire carries no `type` field (verified against live production — the kind is the `id` prefix), so the `item.type` read never matched and the kind label silently never rendered. Derives it from the prefix instead, allowlisted to the four real kinds.

Aligned with today's docs (firecrawl-docs#1291) and blog fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders the artifact kind label in developer search results by deriving it from the `id` prefix. Previously we read `item.type` (not present on the wire), so the label never showed.

- Derives kind from allowlisted prefixes: `doc`, `issue`, `pull_request`, `readme`; unknown prefixes omit the label.
- UI-only change in `src/commands/developer.ts`; no API changes or migrations.

<sup>Written for commit a282a6267315a7f72eec1fb89599bb7d97bb444a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

