### PR TITLE
release: 1.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website, and search a ~43M-abstract research paper index (PubMed, bioRxiv, medRxiv, arXiv), directly from your terminal.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Patch release.

Since 1.21.0:
- #198 — developer-search kind label derived from the `id` prefix (the wire carries no `type` field; the old read silently never rendered).

Merging triggers the publish workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases `firecrawl-cli` 1.21.1 and restores the developer-search artifact-kind label by deriving it from the id prefix, since the wire payload has no type field. Previously the label did not render; now it renders consistently.

- No API or CLI changes; only developer-search rendering is affected.
- Merging this PR triggers the publish workflow.

<sup>Written for commit 8dd52a1d55664372d54a6caea80c192e469d2c20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

