### PR TITLE
Make developer search a lean agent surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,19 +362,20 @@ firecrawl search "AI startups funding" --sources news --tbs qdr:w --limit 15
 
 Search an index built for coding agents: GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. Use it for a programming question: code behaviour, a library or framework, an API contract, an error message, or a known bug.
 
+The CLI intentionally keeps this agent-facing surface lean: it accepts only the query and result count. Express repository, source, result-kind, language, topic, license, and other scoping intent in the query text; semantic retrieval handles the scoping. For advanced filters, use the [Developer Index REST API](https://docs.firecrawl.dev/features/developer).
+
 ```bash
 firecrawl developer "axum middleware ordering"
 ```
 
 #### Options
 
-| Option                | Description                               |
-| --------------------- | ----------------------------------------- |
-| `--limit <n>`         | Number of results (default: 10, max: 100) |
-| `--skills-only`       | Search only agent-skill files             |
-| `-o, --output <path>` | Save to file                              |
-| `--json`              | Output as compact JSON                    |
-| `--pretty`            | Pretty print JSON output                  |
+| Option                | Description                                                |
+| --------------------- | ---------------------------------------------------------- |
+| `--limit <n>`         | Number of results (default: 10, max: 100)                  |
+| `-o, --output <path>` | Save to file                                               |
+| `--json`              | Output full response, including citations and index status |
+| `--pretty`            | Pretty print JSON output                                   |
 
 #### Examples
 
@@ -382,7 +383,10 @@ firecrawl developer "axum middleware ordering"
 # Investigate a known bug
 firecrawl developer "tokio spawn_blocking panics thread limit" --limit 10
 
-# Keep the full passages for an agent
+# Put repository and evidence-kind intent directly in the semantic query
+firecrawl developer "tokio select cancellation safety in tokio-rs/tokio issues and merged pull requests"
+
+# Keep the full response, including passages, citations, and licenses
 firecrawl developer "tokio select cancellation safety" --json -o results.json
 ```
 

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: firecrawl-search
 description: |
-  Web search with full page content. Use when no URL is known: finding sources, articles, or news. For papers use firecrawl-research-index; for library, API, error, or bug questions use firecrawl-developer-index.
+  Web search with full page content extraction, plus routing to Firecrawl's research paper index. Use this skill whenever the user asks to search the web, find articles, research a topic, look something up, find recent news, discover sources, or says "search for", "find me", "look up", "what are people saying about", or "find articles about". Also use it for scientific literature — finding papers, studies, trials, or preprints on PubMed, bioRxiv, medRxiv, or arXiv. Returns real search results with optional full-page markdown — not just snippets. Provides capabilities beyond Claude's built-in WebSearch.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl-cli *)
@@ -10,6 +10,13 @@ allowed-tools:
 # firecrawl search
 
 Web search with optional content scraping. Returns search results as JSON, optionally with full page content.
+
+## When to use
+
+- You don't have a specific URL yet
+- You need to find pages, answer questions, or discover sources
+- You need research papers — see [Paper search](#paper-search), which routes to `firecrawl research`, not to `search --categories research`
+- First step in the [workflow escalation pattern](../firecrawl/SKILL.md): search → scrape → map + scrape → crawl → monitor → interact
 
 ## Quick start
 
@@ -22,18 +29,97 @@ firecrawl search "your query" --scrape -o .firecrawl/scraped.json --json
 
 # News from the past day
 firecrawl search "your query" --sources news --tbs qdr:d -o .firecrawl/news.json --json
+
+# Programming question: search GitHub issues, merged PRs, READMEs, and docs
+firecrawl search "your query" --categories developer -o .firecrawl/developer.json --json
+
+# Research papers: use the paper index, NOT `search --categories research`
+firecrawl research search-papers "your query" -o .firecrawl/papers.json --json
 ```
 
-Run `firecrawl search --help` for the full option list.
+## Developer search
 
-`--categories developer` weighs the developer index beside ordinary web results in this same call (no passage control, no index filters). `--categories research` is a website filter, not the paper index. Dedicated skills: [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md) and [firecrawl-research-index](../firecrawl-research-index/SKILL.md).
+`--categories developer` adds an index built for coding agents. It covers GitHub
+issues, merged pull requests, repository READMEs, and curated documentation
+sites. Use it for a programming question: an error message, an API contract, a
+library behaviour, or a known bug.
 
-**Done when:** results are saved under `.firecrawl/`, verified non-empty, processed for the request, and one feedback event is sent within the time window (unless opted out).
+The hits arrive in their own `data.developer` group beside `data.web`. Each hit
+holds `url`, `title`, and `description`, where `description` is the matched
+passage. Read the passages with
+`jq -r '.data.developer[] | .url, .description' .firecrawl/developer.json`.
+
+The dedicated `firecrawl developer` command searches only that index and keeps
+the full matched passages:
+
+```bash
+# Developer search only, with full passages
+firecrawl developer "your query" --limit 10 -o .firecrawl/developer.json --json
+```
+
+Developer search intentionally accepts only the query and result count. Put
+repository, source, result-kind, language, topic, license, and other scoping
+intent in the query text; semantic retrieval handles it. Advanced filters live
+in the [Developer Index REST API](https://docs.firecrawl.dev/features/developer).
+
+Each result holds `id`, `url`, `title`, and `passages`; infer its kind
+(`issue`, `pull_request`, `readme`, or `doc`) from the `id` prefix. The complete
+JSON response may also carry license disclosures, passage `citation_url` values,
+and top-level indexing status. Read evidence with
+`jq -r '.results[] | .url, .passages[].text' .firecrawl/developer.json`.
+
+## Paper search
+
+**`--categories research` is not the paper index.** It only narrows ordinary web
+results to research-affiliated websites (a short domain allowlist). For actual
+papers use the `firecrawl research` command group, which searches roughly 43M
+abstracts, around 90% biomedical (PubMed, bioRxiv, medRxiv) plus arXiv.
+
+Reach for it on any biomedical, clinical, or scientific-literature question
+instead of web-searching or scraping PubMed, bioRxiv, medRxiv, or Google
+Scholar by hand:
+
+```bash
+# Find papers by topic -- start here, and run several distinct framings
+firecrawl research search-papers "CRISPR base editing off-target effects" \
+  --limit 20 -o .firecrawl/papers.json --json
+
+# Expand from your strongest hits along the citation graph
+firecrawl research related-papers pmid:40953549 --intent "in vivo delivery" \
+  -o .firecrawl/papers-related.json --json
+
+# Verify a specific claim against the full text before you cite it
+firecrawl research read-paper pmcid:PMC12530322 --question "What was the sample size?" \
+  -o .firecrawl/paper-passages.json --json
+```
+
+Paper ids accept `pmid:`, `pmcid:`, `doi:`, and `arxiv:` forms. `inspect-paper`
+returns canonical metadata for one id. Read hits with
+`jq -r '.results[] | .primaryId, .title' .firecrawl/papers.json`.
+
+See [firecrawl](../firecrawl/SKILL.md) for how paper search fits the
+overall command routing.
+
+## Options
+
+| Option                                         | Description                                                                                                                                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--limit <n>`                                  | Max number of results                                                                                                                                              |
+| `--sources <web,images,news>`                  | Source types to search                                                                                                                                             |
+| `--categories <github,research,pdf,developer>` | Filter by category. `research` = research-affiliated websites (see [Paper search](#paper-search) for the actual paper index); `developer` = the coding-agent index |
+| `--tbs <qdr:h\|d\|w\|m\|y>`                    | Time-based search filter                                                                                                                                           |
+| `--location`                                   | Location for search results                                                                                                                                        |
+| `--country <code>`                             | Country code for search                                                                                                                                            |
+| `--scrape`                                     | Also scrape full page content for each result                                                                                                                      |
+| `--scrape-formats`                             | Formats when scraping (default: markdown)                                                                                                                          |
+| `--highlights` / `--no-highlights`             | Query-relevant excerpts vs. original snippets                                                                                                                      |
+| `-o, --output <path>`                          | Output file path                                                                                                                                                   |
+| `--json`                                       | Output as JSON                                                                                                                                                     |
 
 ## Tips
 
 - **`--highlights` on by default:** results are query-relevant excerpts, not full-page snippets. Use `--no-highlights` for the original snippets.
-- **`--scrape` fetches full content** — reuse that content instead of re-scraping result URLs. This saves credits and avoids redundant fetches.
+- **`--scrape` fetches full content** — don't re-scrape URLs from search results. This saves credits and avoids redundant fetches.
 - Always write results to `.firecrawl/` with `-o` to avoid context window bloat.
 - Use `jq` to extract URLs or titles: `jq -r '.data.web[].url' .firecrawl/search.json`
 - Naming convention: `.firecrawl/search-{query}.json` or `.firecrawl/search-{query}-scraped.json`
@@ -47,7 +133,7 @@ Search costs 2 credits. After you've actually used the results (or decided they 
 **Rules to know before you call this:**
 
 - **Time window:** must be sent within ~2 minutes of the search. Late feedback is rejected.
-- **`--missing-content` is the most important field.** It's a list of _specific pieces_ of content you expected but did not find. One topic per entry, each in its own string. These aggregate across teams and tell us what to index next.
+- **`--missing-content` is the most important field.** It's a list of _specific pieces_ of content you expected but did not find. One topic per entry — do not pack multiple topics into one string. These aggregate across teams and tell us what to index next.
 - **Substantive content required** (zero-effort feedback is rejected with HTTP 400):
   - `good` → must include at least one `--valuable-sources` entry.
   - `partial` → must include `--valuable-sources` or `--missing-content`.
@@ -85,5 +171,3 @@ fi
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — scrape a specific URL
 - [firecrawl-map](../firecrawl-map/SKILL.md) — discover URLs within a site
 - [firecrawl-crawl](../firecrawl-crawl/SKILL.md) — bulk extract from a site
-- [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md) — issues, merged PRs, READMEs, and docs
-- [firecrawl-research-index](../firecrawl-research-index/SKILL.md) — published papers, not `search --categories research`

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: firecrawl-search
 description: |
-  Web search with full page content extraction, plus routing to Firecrawl's research paper index. Use this skill whenever the user asks to search the web, find articles, research a topic, look something up, find recent news, discover sources, or says "search for", "find me", "look up", "what are people saying about", or "find articles about". Also use it for scientific literature — finding papers, studies, trials, or preprints on PubMed, bioRxiv, medRxiv, or arXiv. Returns real search results with optional full-page markdown — not just snippets. Provides capabilities beyond Claude's built-in WebSearch.
+  Web search with full page content. Use when no URL is known: finding sources, articles, or news. For papers use firecrawl-research-index; for library, API, error, or bug questions use firecrawl-developer-index.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl-cli *)
@@ -10,13 +10,6 @@ allowed-tools:
 # firecrawl search
 
 Web search with optional content scraping. Returns search results as JSON, optionally with full page content.
-
-## When to use
-
-- You don't have a specific URL yet
-- You need to find pages, answer questions, or discover sources
-- You need research papers — see [Paper search](#paper-search), which routes to `firecrawl research`, not to `search --categories research`
-- First step in the [workflow escalation pattern](../firecrawl/SKILL.md): search → scrape → map + scrape → crawl → monitor → interact
 
 ## Quick start
 
@@ -29,97 +22,18 @@ firecrawl search "your query" --scrape -o .firecrawl/scraped.json --json
 
 # News from the past day
 firecrawl search "your query" --sources news --tbs qdr:d -o .firecrawl/news.json --json
-
-# Programming question: search GitHub issues, merged PRs, READMEs, and docs
-firecrawl search "your query" --categories developer -o .firecrawl/developer.json --json
-
-# Research papers: use the paper index, NOT `search --categories research`
-firecrawl research search-papers "your query" -o .firecrawl/papers.json --json
 ```
 
-## Developer search
+Run `firecrawl search --help` for the full option list.
 
-`--categories developer` adds an index built for coding agents. It covers GitHub
-issues, merged pull requests, repository READMEs, and curated documentation
-sites. Use it for a programming question: an error message, an API contract, a
-library behaviour, or a known bug.
+`--categories developer` weighs the developer index beside ordinary web results in this same call (no passage control, no index filters). `--categories research` is a website filter, not the paper index. Dedicated skills: [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md) and [firecrawl-research-index](../firecrawl-research-index/SKILL.md).
 
-The hits arrive in their own `data.developer` group beside `data.web`. Each hit
-holds `url`, `title`, and `description`, where `description` is the matched
-passage. Read the passages with
-`jq -r '.data.developer[] | .url, .description' .firecrawl/developer.json`.
-
-The dedicated `firecrawl developer` command searches only that index and keeps
-the full matched passages:
-
-```bash
-# Developer search only, with full passages
-firecrawl developer "your query" --limit 10 -o .firecrawl/developer.json --json
-```
-
-Developer search intentionally accepts only the query and result count. Put
-repository, source, result-kind, language, topic, license, and other scoping
-intent in the query text; semantic retrieval handles it. Advanced filters live
-in the [Developer Index REST API](https://docs.firecrawl.dev/features/developer).
-
-Each result holds `id`, `url`, `title`, and `passages`; infer its kind
-(`issue`, `pull_request`, `readme`, or `doc`) from the `id` prefix. The complete
-JSON response may also carry license disclosures, passage `citation_url` values,
-and top-level indexing status. Read evidence with
-`jq -r '.results[] | .url, .passages[].text' .firecrawl/developer.json`.
-
-## Paper search
-
-**`--categories research` is not the paper index.** It only narrows ordinary web
-results to research-affiliated websites (a short domain allowlist). For actual
-papers use the `firecrawl research` command group, which searches roughly 43M
-abstracts, around 90% biomedical (PubMed, bioRxiv, medRxiv) plus arXiv.
-
-Reach for it on any biomedical, clinical, or scientific-literature question
-instead of web-searching or scraping PubMed, bioRxiv, medRxiv, or Google
-Scholar by hand:
-
-```bash
-# Find papers by topic -- start here, and run several distinct framings
-firecrawl research search-papers "CRISPR base editing off-target effects" \
-  --limit 20 -o .firecrawl/papers.json --json
-
-# Expand from your strongest hits along the citation graph
-firecrawl research related-papers pmid:40953549 --intent "in vivo delivery" \
-  -o .firecrawl/papers-related.json --json
-
-# Verify a specific claim against the full text before you cite it
-firecrawl research read-paper pmcid:PMC12530322 --question "What was the sample size?" \
-  -o .firecrawl/paper-passages.json --json
-```
-
-Paper ids accept `pmid:`, `pmcid:`, `doi:`, and `arxiv:` forms. `inspect-paper`
-returns canonical metadata for one id. Read hits with
-`jq -r '.results[] | .primaryId, .title' .firecrawl/papers.json`.
-
-See [firecrawl](../firecrawl/SKILL.md) for how paper search fits the
-overall command routing.
-
-## Options
-
-| Option                                         | Description                                                                                                                                                        |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--limit <n>`                                  | Max number of results                                                                                                                                              |
-| `--sources <web,images,news>`                  | Source types to search                                                                                                                                             |
-| `--categories <github,research,pdf,developer>` | Filter by category. `research` = research-affiliated websites (see [Paper search](#paper-search) for the actual paper index); `developer` = the coding-agent index |
-| `--tbs <qdr:h\|d\|w\|m\|y>`                    | Time-based search filter                                                                                                                                           |
-| `--location`                                   | Location for search results                                                                                                                                        |
-| `--country <code>`                             | Country code for search                                                                                                                                            |
-| `--scrape`                                     | Also scrape full page content for each result                                                                                                                      |
-| `--scrape-formats`                             | Formats when scraping (default: markdown)                                                                                                                          |
-| `--highlights` / `--no-highlights`             | Query-relevant excerpts vs. original snippets                                                                                                                      |
-| `-o, --output <path>`                          | Output file path                                                                                                                                                   |
-| `--json`                                       | Output as JSON                                                                                                                                                     |
+**Done when:** results are saved under `.firecrawl/`, verified non-empty, processed for the request, and one feedback event is sent within the time window (unless opted out).
 
 ## Tips
 
 - **`--highlights` on by default:** results are query-relevant excerpts, not full-page snippets. Use `--no-highlights` for the original snippets.
-- **`--scrape` fetches full content** — don't re-scrape URLs from search results. This saves credits and avoids redundant fetches.
+- **`--scrape` fetches full content** — reuse that content instead of re-scraping result URLs. This saves credits and avoids redundant fetches.
 - Always write results to `.firecrawl/` with `-o` to avoid context window bloat.
 - Use `jq` to extract URLs or titles: `jq -r '.data.web[].url' .firecrawl/search.json`
 - Naming convention: `.firecrawl/search-{query}.json` or `.firecrawl/search-{query}-scraped.json`
@@ -133,7 +47,7 @@ Search costs 2 credits. After you've actually used the results (or decided they 
 **Rules to know before you call this:**
 
 - **Time window:** must be sent within ~2 minutes of the search. Late feedback is rejected.
-- **`--missing-content` is the most important field.** It's a list of _specific pieces_ of content you expected but did not find. One topic per entry — do not pack multiple topics into one string. These aggregate across teams and tell us what to index next.
+- **`--missing-content` is the most important field.** It's a list of _specific pieces_ of content you expected but did not find. One topic per entry, each in its own string. These aggregate across teams and tell us what to index next.
 - **Substantive content required** (zero-effort feedback is rejected with HTTP 400):
   - `good` → must include at least one `--valuable-sources` entry.
   - `partial` → must include `--valuable-sources` or `--missing-content`.
@@ -171,3 +85,5 @@ fi
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — scrape a specific URL
 - [firecrawl-map](../firecrawl-map/SKILL.md) — discover URLs within a site
 - [firecrawl-crawl](../firecrawl-crawl/SKILL.md) — bulk extract from a site
+- [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md) — issues, merged PRs, READMEs, and docs
+- [firecrawl-research-index](../firecrawl-research-index/SKILL.md) — published papers, not `search --categories research`

--- a/src/__tests__/cli-argv.test.ts
+++ b/src/__tests__/cli-argv.test.ts
@@ -30,8 +30,26 @@ describe('CLI argv parsing', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Usage: firecrawl developer');
     expect(result.stdout).toContain('--limit');
-    expect(result.stdout).toContain('--skills-only');
-    expect(result.stdout).not.toContain('--passage-budget');
+    for (const removedFilter of [
+      '--passages',
+      '--types',
+      '--repos',
+      '--sources',
+      '--language',
+      '--topic',
+      '--license',
+      '--min-stars',
+      '--max-stars',
+      '--archived',
+      '--fork',
+      '--skills-only',
+      '--passage-budget',
+    ]) {
+      expect(result.stdout).not.toContain(removedFilter);
+    }
+    expect(result.stdout).toContain('scoping intent in');
+    // Lean surface: the CLI does not point at the REST API for filters.
+    expect(result.stdout).not.toContain('docs.firecrawl.dev');
     expect(result.stderr).not.toContain('unknown command');
   });
 

--- a/src/__tests__/commands/developer.test.ts
+++ b/src/__tests__/commands/developer.test.ts
@@ -23,27 +23,22 @@ describe('handleDeveloperSearchCommand', () => {
   let mockHttpGet: ReturnType<typeof vi.fn>;
 
   // Wrap a payload in the axios envelope returned by `client.http.get`.
-  // Mirrors the `/v2/search/developer` response shape:
-  //   { success, results: [{ id, type, url, title, passages: [{ text }] }] }
-  const mockDeveloperResponse = (
-    results: any[],
-    passageBudgetApplied?: number
-  ) => ({
-    data: {
-      success: true,
-      results,
-      ...(passageBudgetApplied == null
-        ? {}
-        : { passage_budget_applied: passageBudgetApplied }),
-    },
+  const mockDeveloperResponse = (results: any[], extra = {}) => ({
+    data: { success: true, results, ...extra },
   });
 
   const sampleResult = {
     id: 'issue:tokio-rs/tokio#2309',
-    type: 'issue',
     url: 'https://github.com/tokio-rs/tokio/issues/2309',
     title: 'spawn_blocking panics when exceeding the thread limit',
-    passages: [{ text: 'It will panic if this limit is too low.' }],
+    passages: [
+      {
+        text: 'It will panic if this limit is too low.',
+        citation_url:
+          'https://github.com/tokio-rs/tokio/issues/2309#issuecomment-1',
+      },
+    ],
+    license: { state: 'licensed', spdx_id: 'MIT' },
   };
 
   beforeEach(() => {
@@ -76,20 +71,7 @@ describe('handleDeveloperSearchCommand', () => {
       );
     });
 
-    it('passes skills=only when skillsOnly is set', async () => {
-      mockHttpGet.mockResolvedValue(mockDeveloperResponse([sampleResult]));
-
-      await handleDeveloperSearchCommand({
-        query: 'tokio spawn_blocking',
-        skillsOnly: true,
-      });
-
-      expect(mockHttpGet).toHaveBeenCalledWith(
-        '/v2/search/developer?query=tokio+spawn_blocking&skills=only&integration=cli'
-      );
-    });
-
-    it('passes k when a limit is provided', async () => {
+    it('passes k when a result count is provided', async () => {
       mockHttpGet.mockResolvedValue(mockDeveloperResponse([sampleResult]));
 
       await handleDeveloperSearchCommand({
@@ -134,30 +116,21 @@ describe('handleDeveloperSearchCommand', () => {
       expect(content).toContain('It will panic if this limit is too low.');
     });
 
-    it('keeps the legacy local cut when the server omits budget metadata', async () => {
-      mockHttpGet.mockResolvedValue(
-        mockDeveloperResponse([
-          {
-            ...sampleResult,
-            passages: [{ text: 'first passage' }, { text: 'x'.repeat(5000) }],
-          },
-        ])
-      );
-
-      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
-
-      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
-      expect(content).toContain('first passage\n---\nx');
-      const body = content.split('\n').slice(2).join('\n');
-      expect(body.length).toBeLessThanOrEqual(1200);
-    });
-
-    it('does not cut content after the server applies the passage budget', async () => {
+    it('renders full passages, citations, licenses, and indexing echoes', async () => {
       const passage = 'x'.repeat(5000);
       mockHttpGet.mockResolvedValue(
         mockDeveloperResponse(
-          [{ ...sampleResult, passages: [{ text: passage }] }],
-          4096
+          [{ ...sampleResult, passages: [{ text: passage }], license: 'MIT' }],
+          {
+            repos: [
+              {
+                repo: 'tokio-rs/tokio',
+                indexed: true,
+                types: { issue: true, pullRequest: true, readme: false },
+              },
+            ],
+            sources: [{ source: 'rust', indexed: false }],
+          }
         )
       );
 
@@ -165,12 +138,36 @@ describe('handleDeveloperSearchCommand', () => {
 
       const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
       expect(content).toContain(passage);
+      expect(content).toContain('License: MIT');
+      expect(content).toContain('tokio-rs/tokio: indexed');
+      expect(content).toContain('rust: not indexed');
+    });
+
+    it('renders citation URLs and object license disclosures', async () => {
+      mockHttpGet.mockResolvedValue(mockDeveloperResponse([sampleResult]));
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      expect(content).toContain('License: MIT');
+      expect(content).toContain(
+        'Citation: https://github.com/tokio-rs/tokio/issues/2309#issuecomment-1'
+      );
     });
 
     it('prints a placeholder when there are no results', async () => {
       mockHttpGet.mockResolvedValue(mockDeveloperResponse([]));
 
       await handleDeveloperSearchCommand({ query: 'no hits' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0];
+      expect(content).toBe('(no results)');
+    });
+
+    it('tolerates a success response that omits results', async () => {
+      mockHttpGet.mockResolvedValue({ data: { success: true } });
+
+      await handleDeveloperSearchCommand({ query: 'no result field' });
 
       const [content] = vi.mocked(writeOutput).mock.calls[0];
       expect(content).toBe('(no results)');

--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -48,7 +48,7 @@ function fmtResult(item: DeveloperItem): string {
   const lines = [`## [${item.id ?? '?'}]${kind} ${item.title ?? '(untitled)'}`];
   if (item.url) lines.push(item.url);
   if (item.license) lines.push(fmtLicense(item.license));
-  const body = item.passages
+  const body = (item.passages ?? [])
     .map((passage) =>
       [
         passage.text,

--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -1,11 +1,17 @@
 import { getClient, isKeylessMode, keylessGet } from '../utils/client';
 import { writeOutput } from '../utils/output';
-import type { DeveloperItem, DeveloperSearchOptions } from '../types/developer';
+import type {
+  DeveloperItem,
+  DeveloperLicense,
+  DeveloperRepoStatus,
+  DeveloperSearchOptions,
+  DeveloperSearchResponse,
+  DeveloperSourceStatus,
+} from '../types/developer';
 
 // The other mount, /v2/developer/search, rejects keyless callers and may be
 // withdrawn.
 const BASE = '/v2/search/developer';
-const LEGACY_MAX_PASSAGE_CHARS = 1200;
 
 async function getDeveloper<T>(
   path: string,
@@ -22,42 +28,80 @@ async function getDeveloper<T>(
   return (response?.data ?? {}) as T;
 }
 
-function fmtDeveloper(
-  results?: DeveloperItem[],
-  passageBudgetApplied?: number
-): string {
-  if (!results || results.length === 0) return '(no results)';
+function fmtLicense(license: DeveloperLicense | string): string {
+  // During the API migration, license may be either the disclosure object or
+  // its flattened SPDX string. Render both without assuming rollout order.
+  if (typeof license === 'string') return `License: ${license}`;
+  if (license.state === 'licensed' && license.spdx_id) {
+    return `License: ${license.spdx_id}`;
+  }
+  return `License: ${license.state.replace('_', ' ')}`;
+}
 
-  return results
-    .map((item) => {
-      // The wire carries no type field; the artifact kind is the id prefix
-      // (doc:, issue:, pull_request:, readme:).
-      const prefix = (item.id ?? '').split(':', 1)[0];
-      const kind = ['doc', 'issue', 'pull_request', 'readme'].includes(prefix)
-        ? ` (${prefix})`
-        : '';
-      const lines = [
-        `## [${item.id ?? '?'}]${kind} ${item.title ?? '(untitled)'}`,
-      ];
-      if (item.url) lines.push(item.url);
-      const body = (item.passages ?? [])
-        .map((passage) => passage.text ?? '')
-        .join('\n---\n')
-        .trim();
-      // TODO(search#843): Remove this fallback after server passage budgeting
-      // is fully enabled.
-      const renderedBody =
-        passageBudgetApplied == null
-          ? body.slice(0, LEGACY_MAX_PASSAGE_CHARS)
-          : body;
-      lines.push(renderedBody || '(no content)');
-      return lines.join('\n');
-    })
-    .join('\n\n');
+function fmtResult(item: DeveloperItem): string {
+  // The wire carries no type field; the artifact kind is the id prefix
+  // (doc:, issue:, pull_request:, readme:).
+  const prefix = (item.id ?? '').split(':', 1)[0];
+  const kind = ['doc', 'issue', 'pull_request', 'readme'].includes(prefix)
+    ? ` (${prefix})`
+    : '';
+  const lines = [`## [${item.id ?? '?'}]${kind} ${item.title ?? '(untitled)'}`];
+  if (item.url) lines.push(item.url);
+  if (item.license) lines.push(fmtLicense(item.license));
+  const body = item.passages
+    .map((passage) =>
+      [
+        passage.text,
+        passage.citation_url && `Citation: ${passage.citation_url}`,
+      ]
+        .filter(Boolean)
+        .join('\n')
+    )
+    .join('\n---\n')
+    .trim();
+  lines.push(body || '(no content)');
+  return lines.join('\n');
+}
+
+function fmtRepoStatuses(repos: DeveloperRepoStatus[]): string {
+  const lines = ['## Repository indexing'];
+  for (const status of repos) {
+    const indexedTypes = Object.entries(status.types)
+      .filter(([, indexed]) => indexed)
+      .map(([type]) => type)
+      .join(', ');
+    lines.push(
+      `- ${status.repo}: ${status.indexed ? `indexed (${indexedTypes || 'no requested types'})` : 'not indexed'}`
+    );
+  }
+  return lines.join('\n');
+}
+
+function fmtSourceStatuses(sources: DeveloperSourceStatus[]): string {
+  return [
+    '## Documentation source indexing',
+    ...sources.map(
+      (status) =>
+        `- ${status.source}: ${status.indexed ? 'indexed' : 'not indexed'}`
+    ),
+  ].join('\n');
+}
+
+function fmtDeveloper(data: DeveloperSearchResponse): string {
+  const sections: string[] = [];
+  const results = data.results ?? [];
+  if (results.length > 0) {
+    sections.push(results.map(fmtResult).join('\n\n'));
+  } else {
+    sections.push('(no results)');
+  }
+  if (data.repos?.length) sections.push(fmtRepoStatuses(data.repos));
+  if (data.sources?.length) sections.push(fmtSourceStatuses(data.sources));
+  return sections.join('\n\n');
 }
 
 function writeDeveloperOutput(
-  data: unknown,
+  data: DeveloperSearchResponse,
   readable: string,
   options: DeveloperSearchOptions
 ): void {
@@ -85,16 +129,11 @@ export async function handleDeveloperSearchCommand(
     const params = new URLSearchParams();
     params.append('query', options.query);
     if (options.k != null) params.append('k', String(options.k));
-    if (options.skillsOnly) params.append('skills', 'only');
-    const data = await getDeveloper<{
-      results?: DeveloperItem[];
-      passage_budget_applied?: number;
-    }>(`${BASE}?${params.toString()}`, options);
-    writeDeveloperOutput(
-      data,
-      fmtDeveloper(data.results, data.passage_budget_applied),
+    const data = await getDeveloper<DeveloperSearchResponse>(
+      `${BASE}?${params.toString()}`,
       options
     );
+    writeDeveloperOutput(data, fmtDeveloper(data), options);
   } catch (error) {
     handleError(error);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1054,7 +1054,7 @@ function createSearchCommand(): Command {
 function createDeveloperCommand(): Command {
   const developerCmd = new Command('developer')
     .description(
-      'Search an index built for coding agents: issues, merged PRs, repository READMEs, and curated documentation sites. Use it for a programming question: code behaviour, a library or framework, an API contract, an error message, or a known bug. Returns ranked results with id, url, title, and the matched passages in markdown. Kind is the id prefix (doc:, issue:, pull_request:, readme:).'
+      'Search an index built for coding agents: GitHub issues, merged PRs, repository READMEs, and curated documentation sites. Express repository, source, language, topic, license, and other scoping intent in the query text; semantic retrieval handles the scoping.'
     )
     .argument('<query>', 'Natural-language developer question or search phrase')
     .option(
@@ -1063,7 +1063,6 @@ function createDeveloperCommand(): Command {
       parseInt
     )
     .addOption(new Option('--k <number>').argParser(parseInt).hideHelp())
-    .option('--skills-only', 'Search only agent-skill files', false)
     .option(
       '-k, --api-key <key>',
       'Firecrawl API key (overrides global --api-key)'
@@ -1075,8 +1074,11 @@ function createDeveloperCommand(): Command {
     .addHelpText(
       'after',
       `
+Developer search accepts a query and a result count. Put all scoping intent in
+the query text; semantic retrieval handles it.
+
 Examples:
-  $ firecrawl developer "axum middleware ordering" --limit 10
+  $ firecrawl developer "axum middleware ordering in tokio-rs/axum issues" --limit 10
   $ firecrawl developer "tokio select cancellation safety" --json
 `
     )
@@ -1084,7 +1086,6 @@ Examples:
       await handleDeveloperSearchCommand({
         query,
         k: researchLimit(options),
-        skillsOnly: options.skillsOnly,
         apiKey: options.apiKey,
         apiUrl: options.apiUrl,
         output: options.output,

--- a/src/types/developer.ts
+++ b/src/types/developer.ts
@@ -1,7 +1,6 @@
 export interface DeveloperSearchOptions {
   query: string;
   k?: number;
-  skillsOnly?: boolean;
   apiKey?: string;
   apiUrl?: string;
   output?: string;
@@ -9,10 +8,35 @@ export interface DeveloperSearchOptions {
   pretty?: boolean;
 }
 
+export interface DeveloperLicense {
+  state: 'licensed' | 'known_absent' | 'unknown';
+  spdx_id: string | null;
+}
+
 export interface DeveloperItem {
-  id?: string;
-  type?: string;
-  url?: string;
+  id: string;
+  url: string;
   title?: string;
-  passages?: { text?: string }[];
+  passages: { text: string; citation_url?: string }[];
+  // Accept both shapes while the API flattens license disclosures to SPDX strings.
+  license?: DeveloperLicense | string;
+}
+
+export interface DeveloperRepoStatus {
+  repo: string;
+  indexed: boolean;
+  types: { issue: boolean; pullRequest: boolean; readme: boolean };
+}
+
+export interface DeveloperSourceStatus {
+  source: string;
+  indexed: boolean;
+}
+
+export interface DeveloperSearchResponse {
+  success: boolean;
+  // Tolerated wire shape: treated as optional at runtime (`?? []`).
+  results?: DeveloperItem[];
+  repos?: DeveloperRepoStatus[];
+  sources?: DeveloperSourceStatus[];
 }


### PR DESCRIPTION
## Summary
- expose passages, result types, repository/source scopes, and repository metadata filters on `firecrawl developer`
- type and render citation URLs, license disclosures, and repository/source indexing echoes
- remove the stale 1,200-character fallback and correct docs that claimed a wire `type` field
- tolerate both license disclosure objects and flattened SPDX strings during the API rollout

## Audit
Closes the CLI gaps in the completed **Firecrawl Developer Search parity audit** (`/tmp/parity-audit.md`), audited against API gateway `7dbe90f8530f` and CLI 1.21.1 (`bd84b0785577`). In particular, this addresses request matrix gaps 1/5, response gaps 6–9, and the CLI sections cited in that audit.

## Tests
- `pnpm run format:check`
- `pnpm run type-check`
- `pnpm run build`
- `pnpm test` (424 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows the CLI to a lean developer search surface and removes REST API pointers from CLI help. Old behavior: accepted dedicated filters and locally cut passages; new behavior: accepts only the query and result count, renders full server-shaped passages with citation URLs and license disclosures, echoes repo/source indexing status, infers kind from the `id` prefix, includes `repos`/`sources` in `--json`, prints "(no results)" when `results` is missing or empty, and tolerates missing `passages`.

**Migration**
- Stop using removed flags: `--skills-only`, `--passages`, `--types`, `--repos`, `--sources`, `--language`, `--topic`, `--license`, `--min-stars`, `--max-stars`, `--archived`, `--fork`. Put scoping intent in the query text.
- If you parsed `type`, infer the result kind from the `id` prefix (`doc`, `issue`, `pull_request`, `readme`).
- If you consume `--json`, handle new top-level `repos` and `sources` arrays.
- Accept `license` as either a disclosure object or a flattened SPDX string.

<sup>Written for commit d47ed1389a1b0091d1b9bd02c88c32cd1ab545fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

