### PR TITLE
Add developer-index and research-index session skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,9 @@
         "./skills/firecrawl-monitor",
         "./skills/firecrawl-parse",
         "./skills/firecrawl-scrape",
-        "./skills/firecrawl-search"
+        "./skills/firecrawl-search",
+        "./skills/firecrawl-developer-index",
+        "./skills/firecrawl-research-index"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,6 +15,8 @@
     "./skills/firecrawl-monitor",
     "./skills/firecrawl-parse",
     "./skills/firecrawl-scrape",
-    "./skills/firecrawl-search"
+    "./skills/firecrawl-search",
+    "./skills/firecrawl-developer-index",
+    "./skills/firecrawl-research-index"
   ]
 }

--- a/skills/firecrawl-developer-index/SKILL.md
+++ b/skills/firecrawl-developer-index/SKILL.md
@@ -1,26 +1,17 @@
 ---
 name: firecrawl-developer-index
-description: Search issues, merged pull requests, READMEs, and documentation. Use when the question is how a library or API behaves, what an error means, or whether a bug was fixed; prefer this over a general web page.
+description: |
+  Search issues, merged pull requests, READMEs, and documentation. Use when the question is how a library or API behaves, what an error means, or whether a bug was fixed; prefer this over a general web page.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl-cli *)
 ---
 
-# Firecrawl Developer Index
+# firecrawl developer
 
-Answer a developer question from the primary source: the issue where the bug was reported, the merged pull request that fixed it, the README or documentation page that states the contract. A blog post that describes a behaviour is a weaker answer than the passage that defines it, so reach for the index first and the open web second.
+Answer a developer question from the primary source: the issue, the merged pull request that fixed it, or the README/docs passage that states the contract.
 
-There is **no fixed recipe**. Read the question, decide what kind it is, and choose the approach below.
-
-## The tools, and what each is uniquely good at
-
-- CLI: **`firecrawl developer <query>`** — run `firecrawl developer --help` for flags.
-  HTTP: **`GET|POST https://api.firecrawl.dev/v2/search/developer`**
-  MCP: **`firecrawl_developer_search`** (`query`, optional `k` 1–100 default 10, `skills="only"`).
-  Ranked results over the whole index. A successful response is `{success, results}` unless `repos` or `sources` was sent. Each hit carries `id`, `url`, `passages`; `title` is often present; `license: {state, spdx_id}` is often present. Kind is the `id` prefix (`doc:`, `issue:`, `pull_request:`, `readme:`). Hits do not carry a `type` field. Untyped queries can also return `web:` prefixes. Passages are `{text}` and sometimes `{text, citation_url}`.
-  The default first move. It is the only surface that returns the passages, which is what lets you answer instead of pointing at a page.
-  Type, repo, source, and repository-attribute filters are HTTP-only (below).
-  Keyless; send `Authorization: Bearer $FIRECRAWL_API_KEY` for higher rate limits.
+## Quick start
 
 ```bash
 mkdir -p .firecrawl
@@ -28,43 +19,23 @@ firecrawl developer "how do I configure retries" --limit 10 -o .firecrawl/develo
 jq -r '.results[] | .id, .url, .passages[].text' .firecrawl/developer.json
 ```
 
-- CLI: **`firecrawl search <query> --categories developer`**
-  MCP: **`firecrawl_search(query, categories: ["developer"])`**
-  Developer hits in a `developer` group beside `web`, each with `url`, `title`, `description` (the matched passage), `position`, and `category: "developer"` — web results carry no `category`, so that is the field to key on when merging.
-  Use this when you are **already** running a web search and want developer sources weighed in the same call. It exposes none of the filters and no passage control.
+Run `firecrawl developer --help` for the full option list.
 
-- CLI: **`firecrawl scrape <url>` / `firecrawl search <query>`**
-  MCP: **`firecrawl_scrape(url)` / `firecrawl_search(query)`**
-  General web fetch and search, for what no primary source states: a comparison between two libraries, an outage, a migration write-up, a project with no public repository or indexed docs.
-  Also the follow-through when a hit is the right page but you need all of it — `scrape` the result's `url`.
+HTTP: `GET|POST https://api.firecrawl.dev/v2/search/developer`. MCP: `firecrawl_developer_search`. Each hit carries `id`, `url`, `passages`. Kind is the `id` prefix (`doc:`, `issue:`, `pull_request:`, `readme:`). Hits do not carry a `type` field.
 
 **Done when:** the answer quotes a matched passage and cites its `url` (fall back to `url` when `title` is absent), or you have moved to the open web because the index had nothing to say.
 
-## Filters, and what each one costs you
+## Tips
 
-Only the HTTP surface takes these. On `GET`, pass `types=issue,pull_request` or repeat the parameter; on `POST`, pass arrays. All are optional. Confirm CLI flags with `firecrawl developer --help`.
+- Default first move is `firecrawl developer`. Use `search --categories developer` only when you are already running a web search and want developer hits in the same call (no passage control, no index filters).
+- Literal error or stack trace: search the string plus the library name. On HTTP, `types=["issue","pull_request"]`. Strip paths, line numbers, and ids, then retry.
+- API contract: `readme` and `doc` are authoritative. A merged PR supersedes an issue report. Never answer from an opening report alone.
+- Scope last: search the whole index, then narrow with HTTP `types`, `repos`, or `sources`. If a scoped search is empty, read the echoed `indexed` flag before concluding the repo is missing.
+- Repository filters (`language`, `topic`, `license`, `min_stars`, …) drop `doc` results unless you also pass `sources`. `types`, `repos`, `sources`, `passages`, and those repository filters are HTTP-only.
+- Comparison, opinion, news, or an unindexed project: `firecrawl search`, then `firecrawl scrape`.
 
-- `types` — which of `doc`, `issue`, `pull_request`, `readme` to search. Defaults to all four. Narrowing here is the cheapest way to sharpen a query.
-- `repos` (`owner/name`) scopes the repository half, meaning `issue`, `pull_request`, and `readme`; `sources` (documentation source ids, at most 20) scopes the documentation half, meaning `doc`. Passing both **unions** the halves rather than intersecting them. Both echo back in the response with `indexed: true|false` — that is how you tell "not in the index" from "found nothing". `repos` echoes `{repo, indexed, types: {issue, pullRequest, readme}}`; `sources` echoes `{source, indexed}`.
-- A filter that cannot match any requested `type` is a `400`, not an empty list: `repos` with no repository type in `types`, or `sources` without `doc`.
-- `passages` (1–5, default 1) is the _maximum_ passages per result, not a guarantee. Raise it when one page is clearly the right page but the first passage is the wrong part of it.
-- `language`, `topic`, `license`, `min_stars`, `max_stars`, `archived`, `fork` describe a **repository**. Most documentation pages in the index have no repository behind them, so no repository fact can admit or exclude one. Send any of these without a `sources` scope and the response holds repository evidence only — `issue`, `pull_request`, `readme`. That is the design, not an index fault: do not retry it and do not report the index broken. To keep documentation, drop the repository filters, or scope the documentation half with `sources` and read the `sources` echo to confirm the id is indexed.
+## See also
 
-## Match the approach to the question
-
-- **Literal error message or stack-trace string** → search the string itself plus the library name. On HTTP, add `types=["issue","pull_request"]`. Whoever hit it filed it. If nothing matches, strip the volatile parts (paths, line numbers, ids, addresses) and retry — the invariant middle of the message is what is indexed.
-- **Conceptual "how do I do X"** → the full question in natural language. The answer is usually a `doc` or a `readme`. On HTTP, raise `passages` before raising `k`.
-- **Known bug** → the issue reports it, the merged pull request _fixes_ it, and the fix is what you want. Search issues and pull requests, then re-query the issue's own terms scoped to its repo as pull requests only. A merged PR's passages tell you what changed and in which direction.
-- **API contract** ("what does X return", "is Y required", "what is the default") → `readme` and `doc` are authoritative and a blog post is not. If the contract looks like it moved, follow up with `pull_request` for the change that moved it.
-- **Version-specific behaviour** → an issue's opening report describes the broken version; its resolution supersedes it. Raise `passages` (HTTP) to see further into the thread, and read the resolution and the linked pull request before answering. Never answer from an opening report alone.
-- **Scoped to one library** → HTTP `repos=["owner/name"]` when you know the slug, plus `sources` if you want its docs in the same call. If a scoped search comes back empty, read the echoed `indexed` flag first: `false` means nothing from that repo or source can ever match and no rephrasing will help — drop the scope and search the whole index, or go to the web.
-- **Ecosystem-wide** ("which libraries do X", "who else hit this") → no scope. HTTP `language` / `topic` / `min_stars` keep to maintained repositories, accepting that this gives up all `doc` results.
-- **Agent skills and tooling conventions** → `--skills-only` / `skills="only"`.
-- **Comparison, opinion, news, or an unindexed project** → the open web. `firecrawl search`, then `firecrawl scrape` whatever deserves a full read. Combining is often right: take the contract from the index and the trade-off from the web.
-
-## Principles
-
-- **Quote the passage, cite the `url`.** The passages are the evidence; hand them over rather than paraphrasing them into a claim the reader can't check. `title` is frequently absent on `doc` results — fall back to `url`.
-- **A merge supersedes a report.** When an issue and a pull request disagree, the merged pull request is the current behaviour. Say which one you read.
-- **Scope last, not first.** Search the whole index, then narrow with `types`, `repos`, or `sources` once you know what the hits look like. Scoping first hides the result that would have told you where to look.
-- **Go to the web when the index has nothing to say.** Trade-offs, ecosystem opinion, and anything about an unindexed project are web questions. Don't force them through the index, and don't dress a general web page up as a primary source.
+- [firecrawl-search](../firecrawl-search/SKILL.md) — open web, or `search --categories developer` in the same call
+- [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — full page when a hit is right but you need all of it
+- [firecrawl-research-index](../firecrawl-research-index/SKILL.md) — papers, not this index

--- a/skills/firecrawl-developer-index/SKILL.md
+++ b/skills/firecrawl-developer-index/SKILL.md
@@ -10,17 +10,16 @@ allowed-tools:
 
 Answer a developer question from the primary source: the issue where the bug was reported, the merged pull request that fixed it, the README or documentation page that states the contract. A blog post that describes a behaviour is a weaker answer than the passage that defines it, so reach for the index first and the open web second.
 
-There is **no fixed recipe**. Read the question, decide what kind it is, and choose the approach below. A literal error string wants a different move than "how do I do X". Don't run machinery a question doesn't call for.
+There is **no fixed recipe**. Read the question, decide what kind it is, and choose the approach below.
 
 ## The tools, and what each is uniquely good at
 
-- CLI: **`firecrawl developer <query> [--limit <n>] [--skills-only]`**
+- CLI: **`firecrawl developer <query>`** — run `firecrawl developer --help` for flags.
   HTTP: **`GET|POST https://api.firecrawl.dev/v2/search/developer`**
-  MCP: **`firecrawl_developer_search(query, k?, skills?)`**
-  Ranked results over the whole index. Each carries `id` (`issue:owner/repo#123`), `url`, and the **matched passages in markdown**, so tables and code blocks survive. The artifact kind is the `id` prefix: `doc:`, `issue:`, `pull_request:`, or `readme:`. Hits do not carry a `type` field.
-  The default first move for a developer question. It is the only surface that returns the passages, which is what lets you answer instead of pointing at a page.
-  `--limit` / `k` is 1–100 and defaults to 10. `--skills-only` / `skills="only"` restricts the search to agent-skill files.
-  The CLI and MCP surfaces take query, limit, and skills-only. Repository, source, type, and attribute filters are HTTP-only (below).
+  MCP: **`firecrawl_developer_search`** (`query`, optional `k` 1–100 default 10, `skills="only"`).
+  Ranked results over the whole index. A successful response is `{success, results}` unless `repos` or `sources` was sent. Each hit carries `id`, `url`, `passages`; `title` is often present; `license: {state, spdx_id}` is often present. Kind is the `id` prefix (`doc:`, `issue:`, `pull_request:`, `readme:`). Hits do not carry a `type` field. Untyped queries can also return `web:` prefixes. Passages are `{text}` and sometimes `{text, citation_url}`.
+  The default first move. It is the only surface that returns the passages, which is what lets you answer instead of pointing at a page.
+  Type, repo, source, and repository-attribute filters are HTTP-only (below).
   Keyless; send `Authorization: Bearer $FIRECRAWL_API_KEY` for higher rate limits.
 
 ```bash
@@ -39,12 +38,14 @@ jq -r '.results[] | .id, .url, .passages[].text' .firecrawl/developer.json
   General web fetch and search, for what no primary source states: a comparison between two libraries, an outage, a migration write-up, a project with no public repository or indexed docs.
   Also the follow-through when a hit is the right page but you need all of it — `scrape` the result's `url`.
 
+**Done when:** the answer quotes a matched passage and cites its `url` (fall back to `url` when `title` is absent), or you have moved to the open web because the index had nothing to say.
+
 ## Filters, and what each one costs you
 
-Only the HTTP surface takes these. On `GET`, pass `types=issue,pull_request` or repeat the parameter; on `POST`, pass arrays. All are optional. `firecrawl developer` and `firecrawl_developer_search` do not accept them.
+Only the HTTP surface takes these. On `GET`, pass `types=issue,pull_request` or repeat the parameter; on `POST`, pass arrays. All are optional. Confirm CLI flags with `firecrawl developer --help`.
 
 - `types` — which of `doc`, `issue`, `pull_request`, `readme` to search. Defaults to all four. Narrowing here is the cheapest way to sharpen a query.
-- `repos` (`owner/name`) scopes the repository half, meaning `issue`, `pull_request`, and `readme`; `sources` (documentation source ids, at most 20) scopes the documentation half, meaning `doc`. Passing both **unions** the halves rather than intersecting them. Both echo back in the response with `indexed: true|false` — that is how you tell "not in the index" from "found nothing".
+- `repos` (`owner/name`) scopes the repository half, meaning `issue`, `pull_request`, and `readme`; `sources` (documentation source ids, at most 20) scopes the documentation half, meaning `doc`. Passing both **unions** the halves rather than intersecting them. Both echo back in the response with `indexed: true|false` — that is how you tell "not in the index" from "found nothing". `repos` echoes `{repo, indexed, types: {issue, pullRequest, readme}}`; `sources` echoes `{source, indexed}`.
 - A filter that cannot match any requested `type` is a `400`, not an empty list: `repos` with no repository type in `types`, or `sources` without `doc`.
 - `passages` (1–5, default 1) is the _maximum_ passages per result, not a guarantee. Raise it when one page is clearly the right page but the first passage is the wrong part of it.
 - `language`, `topic`, `license`, `min_stars`, `max_stars`, `archived`, `fork` describe a **repository**. Most documentation pages in the index have no repository behind them, so no repository fact can admit or exclude one. Send any of these without a `sources` scope and the response holds repository evidence only — `issue`, `pull_request`, `readme`. That is the design, not an index fault: do not retry it and do not report the index broken. To keep documentation, drop the repository filters, or scope the documentation half with `sources` and read the `sources` echo to confirm the id is indexed.

--- a/skills/firecrawl-developer-index/SKILL.md
+++ b/skills/firecrawl-developer-index/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: firecrawl-developer-index
+description: Search issues, merged pull requests, READMEs, and documentation. Use when the question is how a library or API behaves, what an error means, or whether a bug was fixed; prefer this over a general web page.
+allowed-tools:
+  - Bash(firecrawl *)
+  - Bash(npx firecrawl-cli *)
+---
+
+# Firecrawl Developer Index
+
+Answer a developer question from the primary source: the issue where the bug was reported, the merged pull request that fixed it, the README or documentation page that states the contract. A blog post that describes a behaviour is a weaker answer than the passage that defines it, so reach for the index first and the open web second.
+
+There is **no fixed recipe**. Read the question, decide what kind it is, and choose the approach below. A literal error string wants a different move than "how do I do X". Don't run machinery a question doesn't call for.
+
+## The tools, and what each is uniquely good at
+
+- CLI: **`firecrawl developer <query> [--limit <n>] [--skills-only]`**
+  HTTP: **`GET|POST https://api.firecrawl.dev/v2/search/developer`**
+  MCP: **`firecrawl_developer_search(query, k?, skills?)`**
+  Ranked results over the whole index. Each carries `id` (`issue:owner/repo#123`), `url`, and the **matched passages in markdown**, so tables and code blocks survive. The artifact kind is the `id` prefix: `doc:`, `issue:`, `pull_request:`, or `readme:`. Hits do not carry a `type` field.
+  The default first move for a developer question. It is the only surface that returns the passages, which is what lets you answer instead of pointing at a page.
+  `--limit` / `k` is 1–100 and defaults to 10. `--skills-only` / `skills="only"` restricts the search to agent-skill files.
+  The CLI and MCP surfaces take query, limit, and skills-only. Repository, source, type, and attribute filters are HTTP-only (below).
+  Keyless; send `Authorization: Bearer $FIRECRAWL_API_KEY` for higher rate limits.
+
+```bash
+mkdir -p .firecrawl
+firecrawl developer "how do I configure retries" --limit 10 -o .firecrawl/developer.json --json
+jq -r '.results[] | .id, .url, .passages[].text' .firecrawl/developer.json
+```
+
+- CLI: **`firecrawl search <query> --categories developer`**
+  MCP: **`firecrawl_search(query, categories: ["developer"])`**
+  Developer hits in a `developer` group beside `web`, each with `url`, `title`, `description` (the matched passage), `position`, and `category: "developer"` — web results carry no `category`, so that is the field to key on when merging.
+  Use this when you are **already** running a web search and want developer sources weighed in the same call. It exposes none of the filters and no passage control.
+
+- CLI: **`firecrawl scrape <url>` / `firecrawl search <query>`**
+  MCP: **`firecrawl_scrape(url)` / `firecrawl_search(query)`**
+  General web fetch and search, for what no primary source states: a comparison between two libraries, an outage, a migration write-up, a project with no public repository or indexed docs.
+  Also the follow-through when a hit is the right page but you need all of it — `scrape` the result's `url`.
+
+## Filters, and what each one costs you
+
+Only the HTTP surface takes these. On `GET`, pass `types=issue,pull_request` or repeat the parameter; on `POST`, pass arrays. All are optional. `firecrawl developer` and `firecrawl_developer_search` do not accept them.
+
+- `types` — which of `doc`, `issue`, `pull_request`, `readme` to search. Defaults to all four. Narrowing here is the cheapest way to sharpen a query.
+- `repos` (`owner/name`) scopes the repository half, meaning `issue`, `pull_request`, and `readme`; `sources` (documentation source ids, at most 20) scopes the documentation half, meaning `doc`. Passing both **unions** the halves rather than intersecting them. Both echo back in the response with `indexed: true|false` — that is how you tell "not in the index" from "found nothing".
+- A filter that cannot match any requested `type` is a `400`, not an empty list: `repos` with no repository type in `types`, or `sources` without `doc`.
+- `passages` (1–5, default 1) is the _maximum_ passages per result, not a guarantee. Raise it when one page is clearly the right page but the first passage is the wrong part of it.
+- `language`, `topic`, `license`, `min_stars`, `max_stars`, `archived`, `fork` describe a **repository**. Most documentation pages in the index have no repository behind them, so no repository fact can admit or exclude one. Send any of these without a `sources` scope and the response holds repository evidence only — `issue`, `pull_request`, `readme`. That is the design, not an index fault: do not retry it and do not report the index broken. To keep documentation, drop the repository filters, or scope the documentation half with `sources` and read the `sources` echo to confirm the id is indexed.
+
+## Match the approach to the question
+
+- **Literal error message or stack-trace string** → search the string itself plus the library name. On HTTP, add `types=["issue","pull_request"]`. Whoever hit it filed it. If nothing matches, strip the volatile parts (paths, line numbers, ids, addresses) and retry — the invariant middle of the message is what is indexed.
+- **Conceptual "how do I do X"** → the full question in natural language. The answer is usually a `doc` or a `readme`. On HTTP, raise `passages` before raising `k`.
+- **Known bug** → the issue reports it, the merged pull request _fixes_ it, and the fix is what you want. Search issues and pull requests, then re-query the issue's own terms scoped to its repo as pull requests only. A merged PR's passages tell you what changed and in which direction.
+- **API contract** ("what does X return", "is Y required", "what is the default") → `readme` and `doc` are authoritative and a blog post is not. If the contract looks like it moved, follow up with `pull_request` for the change that moved it.
+- **Version-specific behaviour** → an issue's opening report describes the broken version; its resolution supersedes it. Raise `passages` (HTTP) to see further into the thread, and read the resolution and the linked pull request before answering. Never answer from an opening report alone.
+- **Scoped to one library** → HTTP `repos=["owner/name"]` when you know the slug, plus `sources` if you want its docs in the same call. If a scoped search comes back empty, read the echoed `indexed` flag first: `false` means nothing from that repo or source can ever match and no rephrasing will help — drop the scope and search the whole index, or go to the web.
+- **Ecosystem-wide** ("which libraries do X", "who else hit this") → no scope. HTTP `language` / `topic` / `min_stars` keep to maintained repositories, accepting that this gives up all `doc` results.
+- **Agent skills and tooling conventions** → `--skills-only` / `skills="only"`.
+- **Comparison, opinion, news, or an unindexed project** → the open web. `firecrawl search`, then `firecrawl scrape` whatever deserves a full read. Combining is often right: take the contract from the index and the trade-off from the web.
+
+## Principles
+
+- **Quote the passage, cite the `url`.** The passages are the evidence; hand them over rather than paraphrasing them into a claim the reader can't check. `title` is frequently absent on `doc` results — fall back to `url`.
+- **A merge supersedes a report.** When an issue and a pull request disagree, the merged pull request is the current behaviour. Say which one you read.
+- **Scope last, not first.** Search the whole index, then narrow with `types`, `repos`, or `sources` once you know what the hits look like. Scoping first hides the result that would have told you where to look.
+- **Go to the web when the index has nothing to say.** Trade-offs, ecosystem opinion, and anything about an unindexed project are web questions. Don't force them through the index, and don't dress a general web page up as a primary source.

--- a/skills/firecrawl-research-index/SKILL.md
+++ b/skills/firecrawl-research-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firecrawl-research-index
-description: Find the papers that answer a research query in Firecrawl's research paper index — a corpus of paper abstracts whose largest share is biomedical and life-science literature (PubMed, bioRxiv, medRxiv), alongside arXiv preprints in CS, physics, and math — using semantic search, semantic and structural expansion, and in-body verification. Use this skill for literature-finding and paper-retrieval tasks of any kind, including clinical, biomedical, drug, gene, disease, and other life-science questions, whether the answer is a single paper or a full multi-paper set. The index is reached only through the `firecrawl_research_*` MCP tools or the `firecrawl research` CLI subcommands. Calling `firecrawl_search` with its `categories` option set to `["research"]` is a different feature — it filters ordinary web search to research-affiliated websites (the list includes PubMed, bioRxiv, medRxiv, arXiv, and publisher sites) and returns page results from them, without querying the paper records in this index.
+description: Find papers in Firecrawl's research paper index (PubMed, bioRxiv, medRxiv, arXiv). Use for literature-finding of any kind, including clinical and biomedical questions; `search --categories research` is a website filter, not this index.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl-cli *)
@@ -8,18 +8,20 @@ allowed-tools:
 
 # Firecrawl Research Index
 
-Find the research papers that answer a research query. Some questions have a single answer; many have several — and when in doubt, lean toward returning the fuller relevant set (most relevant first) rather than narrowing to one. A reader is better served seeing the neighboring methods and papers than having them silently dropped.
+Find the research papers that answer a research query. Some questions have a single answer; many have several — and when in doubt, lean toward returning the fuller relevant set (most relevant first) rather than narrowing to one.
 
 ## What is in the index
 
 Paper abstracts, with full text reachable per paper. The largest share of the corpus is **biomedical and life-science** literature — **PubMed** journal articles plus **bioRxiv** and **medRxiv** preprints — so clinical, drug, gene, disease, epidemiology, and public-health questions are in scope. **arXiv** preprints cover computer science, physics, and mathematics. Coverage outside those sources is thinner: a paper that exists only behind a publisher paywall or in a niche venue may not be indexed, and the general web tools below are the fallback when it isn't.
 
-There is **no fixed recipe**. Read the query, decide what kind it is, and choose the approach below. Some queries need a single search; others need heavy structural/semantic expansion. Don't run machinery a query doesn't call for.
+There is **no fixed recipe**. Read the query, decide what kind it is, and choose the approach below.
 
 ## The tools, and what each is uniquely good at
 
-- CLI: **`firecrawl research search-papers <query> [--limit <number>]`**
-  MCP: **`firecrawl_research_search_papers(query, k?)`**
+Run `firecrawl research <subcommand> --help` for flags. MCP tool arguments are the schema your client shows (`paperId`, not `id`).
+
+- CLI: **`firecrawl research search-papers <query>`**
+  MCP: **`firecrawl_research_search_papers`**
   Semantic (HyDE) search over **abstracts**. The natural first move for almost any query.
   A successful response is `{success, results}`. Each hit carries `paperId`, `primaryId` (`pmid:`, `pmcid:`, `doi:`, or `arxiv:`), `ids`, `title`, `abstract`, and `score`.
   If results look thin or all-alike, re-run with a different framing (sibling domain, rival method, dataset/benchmark name) rather than giving up.
@@ -31,34 +33,34 @@ firecrawl research search-papers "CRISPR base editing off-target effects" \
 jq -r '.results[] | .primaryId, .title' .firecrawl/papers.json
 ```
 
-- CLI: **`firecrawl research related-papers <seedIds...> --intent <intent> [--mode <similar|citers|references>] [--limit <number>]`**
-  MCP: **`firecrawl_research_related_papers(seed_ids, intent, mode?, k?)`**
-  Semantic and structural expansion, ranked to your `intent`.
+- CLI: **`firecrawl research related-papers <seedIds...> --intent <intent>`**
+  MCP: **`firecrawl_research_related_papers`**
+  Semantic and structural expansion, ranked to your `intent`. `--intent` is required.
   This reaches papers semantic search _cannot_, and it's how you turn one good hit into the rest of a set.
   `mode=similar` → niche siblings; `citers` → who uses/builds on the seeds; `references` → what they build on / compare against.
 
-- CLI: **`firecrawl research inspect-paper <id>`**
-  MCP: **`firecrawl_research_inspect_paper(id)`**
+- CLI: **`firecrawl research inspect-paper <paperId>`**
+  MCP: **`firecrawl_research_inspect_paper`**
   Canonical metadata for **one** paper: title, abstract, authors, categories, source ids, and dates.
   Use it after `search-papers` or `related-papers` when you need the complete citation/metadata for a candidate, or when you have an id from elsewhere and need to confirm what paper it resolves to.
   This does **not** read the paper body; use `read-paper` for specific full-text questions.
 
-- CLI: **`firecrawl research read-paper <id> --question <question>`**
-  MCP: **`firecrawl_research_read_paper(id, question)`**
+- CLI: **`firecrawl research read-paper <paperId> --question <question>`**
+  MCP: **`firecrawl_research_read_paper`**
   In-body passages of **one** paper, to verify a load-bearing constraint (a method actually used, a score actually reported, an affiliation, what a paper compares to).
   Use it to settle a specific doubt, not on everything.
 
 - CLI: **`firecrawl search <query> --categories research`**
   MCP: **`firecrawl_search(query, categories: ["research"])`**
   **Not this index.** This is a _website_ filter: it restricts a normal web search to a short list of research-affiliated domains — the list does include `pubmed.ncbi.nlm.nih.gov`, `biorxiv.org`, `medrxiv.org`, and `arxiv.org` alongside publisher sites — and returns page results in a `research` group beside `web`, each with `url`, `title`, `description` (the matched passage), `position`, and `category: "research"` — web results carry no `category`, so that is the field to key on when merging.
-  So it reaches those sites' **web pages**; what it does not do is query their **paper records** in this index — no semantic search over abstracts, no citation-graph or related-paper expansion, no canonical paper metadata, and no in-body passages. The results are ordinary web results.
-  Use it when you are **already** running a web search and want those sites weighed in the same call. For anything that is actually a paper-finding task, use `firecrawl research search-papers` and its siblings above.
+  So it reaches those sites' **web pages**; what it does not do is query their **paper records** in this index. For a paper-finding task, use `firecrawl research search-papers` and its siblings above.
 
 - CLI: **`firecrawl search <query>` / `firecrawl scrape <url>`**
   MCP: **`firecrawl_search(query)` / `firecrawl_scrape(url)`**
   General **web** search and page fetch, for facts that don't live in paper abstracts: benchmark **leaderboards**, rankings, "who scores best / is largest / is most used."
   Find the ranking on the web, then map the top entries back to papers with `search-papers`.
-  Reach for these only when the corpus can't answer the question on its own.
+
+**Done when:** the answer is a cited paper set (or the one named paper), each kept or dropped against a verified constraint, with `search-papers` as the first move unless the query already named an id.
 
 ## Match the approach to the query
 
@@ -66,15 +68,15 @@ jq -r '.results[] | .primaryId, .title' .firecrawl/papers.json
 - **Paper by description / by method or technique** ("the paper that introduced X", "training-free N-gram detection of AI text") → find the best match, then assume there's a _family_: expand with `related-papers` and **include the closely-related methods/papers too**. Even when one paper is the exact literal match, surface and keep its neighbors — don't narrow to the single best hit and reason the rest out. Only treat it as one-answer if the query names a specific paper.
 - **Enumeration / method-family** ("papers that do X", "alternatives to Adam", "benchmarks for Y") → the answer is a _set_, and this is where `related-papers` earns its keep: expand several strong anchors with `mode=similar`, re-seed from new strong hits. One search is never enough here.
 - **Exhibiting** ("papers that _use_ / exhibit property P") → the relevant papers apply P but their abstracts may not describe it. Go from P's defining paper outward via `citers`/`references`, and use `read-paper` to confirm a candidate actually uses P.
-- **Superlative / leaderboard** ("best on benchmark X", "largest", "most popular") → the ranking lives on **leaderboards / the web**, not in any single abstract. Use `firecrawl search` / `firecrawl scrape` to find the benchmark's leaderboard or rankings, read off the top models/papers, then `search-papers` each to get its paper. As a fallback, search the benchmark and `read-paper` candidates for reported numbers. The hardest kind — cast wide.
+- **Superlative / leaderboard** ("best on benchmark X", "largest", "most popular") → the ranking lives on **leaderboards / the web**, not in any single abstract. Use `firecrawl search` / `firecrawl scrape` to find the benchmark's leaderboard or rankings, read off the top models/papers, then `search-papers` each to get its paper. As a fallback, search the benchmark and `read-paper` candidates for reported numbers.
 - **Org / author filtered** ("from \<org\>", "by \<author\>") → topical match isn't enough; verify the affiliation/authorship (metadata or `read-paper`) before keeping a paper.
 - **Compare-against** ("what does paper X benchmark against / build on") → the answer is _inside_ paper X: `read-paper(X, ...)` or `related-papers` with `mode=references`.
 
 ## Principles
 
-- **Two different features share the word "research."** The paper index is `firecrawl research` / `firecrawl_research_*`. The `categories: ["research"]` option on `firecrawl search` is a website filter — it does point web search at PubMed, bioRxiv, medRxiv, arXiv, and publisher sites, but what comes back is their web pages, not paper records. If a task is about finding papers, the tools in this skill are the ones that read the corpus; reaching for `categories: ["research"]` will quietly answer a different question.
+- **Two different features share the word "research."** The paper index is `firecrawl research` / `firecrawl_research_*`. The `categories: ["research"]` option on `firecrawl search` is a website filter — it does point web search at PubMed, bioRxiv, medRxiv, arXiv, and publisher sites, but what comes back is their web pages, not paper records. If a task is about finding papers, the tools in this skill are the ones that read the corpus.
 - **Query shape and subject field are separate.** A clinical-trial question and a machine-learning question take the same shapes above; what differs is only which source the hits come from. Don't send a biomedical or life-science query to the open web on the assumption the corpus is arXiv-only — PubMed, bioRxiv, and medRxiv are the largest part of what `search-papers` reads.
-- **When in doubt, include.** For any topic / method / comparison question, return the relevant _family_, not just the single best match — err toward keeping a plausibly-relevant paper rather than dropping it. The neighboring methods are part of a good answer; don't reason close work out just because one paper is the most exact match.
-- **Follow the literature, and keep what you find.** The seminal source, the competing methods, the close neighbors are usually a hop away — use `related-papers`, and _include_ them, not just the first hit. Stopping at one good result is the most common way to leave the reader with half an answer.
+- **When in doubt, include.** For any topic / method / comparison question, return the relevant _family_, not just the single best match. The neighboring methods are part of a good answer.
+- **Follow the literature, and keep what you find.** The seminal source, the competing methods, the close neighbors are usually a hop away — use `related-papers`, and _include_ them, not just the first hit.
 - **Verify to exclude, not to gatekeep.** Use `read-paper` to rule a paper _out_ when a hard constraint clearly fails (wrong org/author, doesn't actually report the score). When a paper is plausibly relevant, lean toward keeping it rather than demanding proof.
 - **Only drop the clearly off-topic.** Don't pad with papers you're confident are unrelated — but that's a high bar; most plausibly-relevant work should make the cut.

--- a/skills/firecrawl-research-index/SKILL.md
+++ b/skills/firecrawl-research-index/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: firecrawl-research-index
+description: Find the papers that answer a research query in Firecrawl's research paper index — a corpus of paper abstracts whose largest share is biomedical and life-science literature (PubMed, bioRxiv, medRxiv), alongside arXiv preprints in CS, physics, and math — using semantic search, semantic and structural expansion, and in-body verification. Use this skill for literature-finding and paper-retrieval tasks of any kind, including clinical, biomedical, drug, gene, disease, and other life-science questions, whether the answer is a single paper or a full multi-paper set. The index is reached only through the `firecrawl_research_*` MCP tools or the `firecrawl research` CLI subcommands. Calling `firecrawl_search` with its `categories` option set to `["research"]` is a different feature — it filters ordinary web search to research-affiliated websites (the list includes PubMed, bioRxiv, medRxiv, arXiv, and publisher sites) and returns page results from them, without querying the paper records in this index.
+allowed-tools:
+  - Bash(firecrawl *)
+  - Bash(npx firecrawl-cli *)
+---
+
+# Firecrawl Research Index
+
+Find the research papers that answer a research query. Some questions have a single answer; many have several — and when in doubt, lean toward returning the fuller relevant set (most relevant first) rather than narrowing to one. A reader is better served seeing the neighboring methods and papers than having them silently dropped.
+
+## What is in the index
+
+Paper abstracts, with full text reachable per paper. The largest share of the corpus is **biomedical and life-science** literature — **PubMed** journal articles plus **bioRxiv** and **medRxiv** preprints — so clinical, drug, gene, disease, epidemiology, and public-health questions are in scope. **arXiv** preprints cover computer science, physics, and mathematics. Coverage outside those sources is thinner: a paper that exists only behind a publisher paywall or in a niche venue may not be indexed, and the general web tools below are the fallback when it isn't.
+
+There is **no fixed recipe**. Read the query, decide what kind it is, and choose the approach below. Some queries need a single search; others need heavy structural/semantic expansion. Don't run machinery a query doesn't call for.
+
+## The tools, and what each is uniquely good at
+
+- CLI: **`firecrawl research search-papers <query> [--limit <number>]`**
+  MCP: **`firecrawl_research_search_papers(query, k?)`**
+  Semantic (HyDE) search over **abstracts**. The natural first move for almost any query.
+  A successful response is `{success, results}`. Each hit carries `paperId`, `primaryId` (`pmid:`, `pmcid:`, `doi:`, or `arxiv:`), `ids`, `title`, `abstract`, and `score`.
+  If results look thin or all-alike, re-run with a different framing (sibling domain, rival method, dataset/benchmark name) rather than giving up.
+
+```bash
+mkdir -p .firecrawl
+firecrawl research search-papers "CRISPR base editing off-target effects" \
+  --limit 20 -o .firecrawl/papers.json --json
+jq -r '.results[] | .primaryId, .title' .firecrawl/papers.json
+```
+
+- CLI: **`firecrawl research related-papers <seedIds...> --intent <intent> [--mode <similar|citers|references>] [--limit <number>]`**
+  MCP: **`firecrawl_research_related_papers(seed_ids, intent, mode?, k?)`**
+  Semantic and structural expansion, ranked to your `intent`.
+  This reaches papers semantic search _cannot_, and it's how you turn one good hit into the rest of a set.
+  `mode=similar` → niche siblings; `citers` → who uses/builds on the seeds; `references` → what they build on / compare against.
+
+- CLI: **`firecrawl research inspect-paper <id>`**
+  MCP: **`firecrawl_research_inspect_paper(id)`**
+  Canonical metadata for **one** paper: title, abstract, authors, categories, source ids, and dates.
+  Use it after `search-papers` or `related-papers` when you need the complete citation/metadata for a candidate, or when you have an id from elsewhere and need to confirm what paper it resolves to.
+  This does **not** read the paper body; use `read-paper` for specific full-text questions.
+
+- CLI: **`firecrawl research read-paper <id> --question <question>`**
+  MCP: **`firecrawl_research_read_paper(id, question)`**
+  In-body passages of **one** paper, to verify a load-bearing constraint (a method actually used, a score actually reported, an affiliation, what a paper compares to).
+  Use it to settle a specific doubt, not on everything.
+
+- CLI: **`firecrawl search <query> --categories research`**
+  MCP: **`firecrawl_search(query, categories: ["research"])`**
+  **Not this index.** This is a _website_ filter: it restricts a normal web search to a short list of research-affiliated domains — the list does include `pubmed.ncbi.nlm.nih.gov`, `biorxiv.org`, `medrxiv.org`, and `arxiv.org` alongside publisher sites — and returns page results in a `research` group beside `web`, each with `url`, `title`, `description` (the matched passage), `position`, and `category: "research"` — web results carry no `category`, so that is the field to key on when merging.
+  So it reaches those sites' **web pages**; what it does not do is query their **paper records** in this index — no semantic search over abstracts, no citation-graph or related-paper expansion, no canonical paper metadata, and no in-body passages. The results are ordinary web results.
+  Use it when you are **already** running a web search and want those sites weighed in the same call. For anything that is actually a paper-finding task, use `firecrawl research search-papers` and its siblings above.
+
+- CLI: **`firecrawl search <query>` / `firecrawl scrape <url>`**
+  MCP: **`firecrawl_search(query)` / `firecrawl_scrape(url)`**
+  General **web** search and page fetch, for facts that don't live in paper abstracts: benchmark **leaderboards**, rankings, "who scores best / is largest / is most used."
+  Find the ranking on the web, then map the top entries back to papers with `search-papers`.
+  Reach for these only when the corpus can't answer the question on its own.
+
+## Match the approach to the query
+
+- **Single _named_ paper** ("the Qwen3 report") → one `search-papers`, done. This is the only case that truly wants exactly one paper.
+- **Paper by description / by method or technique** ("the paper that introduced X", "training-free N-gram detection of AI text") → find the best match, then assume there's a _family_: expand with `related-papers` and **include the closely-related methods/papers too**. Even when one paper is the exact literal match, surface and keep its neighbors — don't narrow to the single best hit and reason the rest out. Only treat it as one-answer if the query names a specific paper.
+- **Enumeration / method-family** ("papers that do X", "alternatives to Adam", "benchmarks for Y") → the answer is a _set_, and this is where `related-papers` earns its keep: expand several strong anchors with `mode=similar`, re-seed from new strong hits. One search is never enough here.
+- **Exhibiting** ("papers that _use_ / exhibit property P") → the relevant papers apply P but their abstracts may not describe it. Go from P's defining paper outward via `citers`/`references`, and use `read-paper` to confirm a candidate actually uses P.
+- **Superlative / leaderboard** ("best on benchmark X", "largest", "most popular") → the ranking lives on **leaderboards / the web**, not in any single abstract. Use `firecrawl search` / `firecrawl scrape` to find the benchmark's leaderboard or rankings, read off the top models/papers, then `search-papers` each to get its paper. As a fallback, search the benchmark and `read-paper` candidates for reported numbers. The hardest kind — cast wide.
+- **Org / author filtered** ("from \<org\>", "by \<author\>") → topical match isn't enough; verify the affiliation/authorship (metadata or `read-paper`) before keeping a paper.
+- **Compare-against** ("what does paper X benchmark against / build on") → the answer is _inside_ paper X: `read-paper(X, ...)` or `related-papers` with `mode=references`.
+
+## Principles
+
+- **Two different features share the word "research."** The paper index is `firecrawl research` / `firecrawl_research_*`. The `categories: ["research"]` option on `firecrawl search` is a website filter — it does point web search at PubMed, bioRxiv, medRxiv, arXiv, and publisher sites, but what comes back is their web pages, not paper records. If a task is about finding papers, the tools in this skill are the ones that read the corpus; reaching for `categories: ["research"]` will quietly answer a different question.
+- **Query shape and subject field are separate.** A clinical-trial question and a machine-learning question take the same shapes above; what differs is only which source the hits come from. Don't send a biomedical or life-science query to the open web on the assumption the corpus is arXiv-only — PubMed, bioRxiv, and medRxiv are the largest part of what `search-papers` reads.
+- **When in doubt, include.** For any topic / method / comparison question, return the relevant _family_, not just the single best match — err toward keeping a plausibly-relevant paper rather than dropping it. The neighboring methods are part of a good answer; don't reason close work out just because one paper is the most exact match.
+- **Follow the literature, and keep what you find.** The seminal source, the competing methods, the close neighbors are usually a hop away — use `related-papers`, and _include_ them, not just the first hit. Stopping at one good result is the most common way to leave the reader with half an answer.
+- **Verify to exclude, not to gatekeep.** Use `read-paper` to rule a paper _out_ when a hard constraint clearly fails (wrong org/author, doesn't actually report the score). When a paper is plausibly relevant, lean toward keeping it rather than demanding proof.
+- **Only drop the clearly off-topic.** Don't pad with papers you're confident are unrelated — but that's a high bar; most plausibly-relevant work should make the cut.

--- a/skills/firecrawl-research-index/SKILL.md
+++ b/skills/firecrawl-research-index/SKILL.md
@@ -1,30 +1,17 @@
 ---
 name: firecrawl-research-index
-description: Find papers in Firecrawl's research paper index (PubMed, bioRxiv, medRxiv, arXiv). Use for literature-finding of any kind, including clinical and biomedical questions; `search --categories research` is a website filter, not this index.
+description: |
+  Find papers in Firecrawl's research paper index (PubMed, bioRxiv, medRxiv, arXiv). Use for literature-finding of any kind, including clinical and biomedical questions; `search --categories research` is a website filter, not this index.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl-cli *)
 ---
 
-# Firecrawl Research Index
+# firecrawl research
 
-Find the research papers that answer a research query. Some questions have a single answer; many have several — and when in doubt, lean toward returning the fuller relevant set (most relevant first) rather than narrowing to one.
+Find the papers that answer a research query. When in doubt, return the relevant set (most relevant first) rather than one hit.
 
-## What is in the index
-
-Paper abstracts, with full text reachable per paper. The largest share of the corpus is **biomedical and life-science** literature — **PubMed** journal articles plus **bioRxiv** and **medRxiv** preprints — so clinical, drug, gene, disease, epidemiology, and public-health questions are in scope. **arXiv** preprints cover computer science, physics, and mathematics. Coverage outside those sources is thinner: a paper that exists only behind a publisher paywall or in a niche venue may not be indexed, and the general web tools below are the fallback when it isn't.
-
-There is **no fixed recipe**. Read the query, decide what kind it is, and choose the approach below.
-
-## The tools, and what each is uniquely good at
-
-Run `firecrawl research <subcommand> --help` for flags. MCP tool arguments are the schema your client shows (`paperId`, not `id`).
-
-- CLI: **`firecrawl research search-papers <query>`**
-  MCP: **`firecrawl_research_search_papers`**
-  Semantic (HyDE) search over **abstracts**. The natural first move for almost any query.
-  A successful response is `{success, results}`. Each hit carries `paperId`, `primaryId` (`pmid:`, `pmcid:`, `doi:`, or `arxiv:`), `ids`, `title`, `abstract`, and `score`.
-  If results look thin or all-alike, re-run with a different framing (sibling domain, rival method, dataset/benchmark name) rather than giving up.
+## Quick start
 
 ```bash
 mkdir -p .firecrawl
@@ -33,50 +20,24 @@ firecrawl research search-papers "CRISPR base editing off-target effects" \
 jq -r '.results[] | .primaryId, .title' .firecrawl/papers.json
 ```
 
-- CLI: **`firecrawl research related-papers <seedIds...> --intent <intent>`**
-  MCP: **`firecrawl_research_related_papers`**
-  Semantic and structural expansion, ranked to your `intent`. `--intent` is required.
-  This reaches papers semantic search _cannot_, and it's how you turn one good hit into the rest of a set.
-  `mode=similar` → niche siblings; `citers` → who uses/builds on the seeds; `references` → what they build on / compare against.
+Run `firecrawl research <subcommand> --help` for flags. MCP arguments use `paperId`, not `id`.
 
-- CLI: **`firecrawl research inspect-paper <paperId>`**
-  MCP: **`firecrawl_research_inspect_paper`**
-  Canonical metadata for **one** paper: title, abstract, authors, categories, source ids, and dates.
-  Use it after `search-papers` or `related-papers` when you need the complete citation/metadata for a candidate, or when you have an id from elsewhere and need to confirm what paper it resolves to.
-  This does **not** read the paper body; use `read-paper` for specific full-text questions.
-
-- CLI: **`firecrawl research read-paper <paperId> --question <question>`**
-  MCP: **`firecrawl_research_read_paper`**
-  In-body passages of **one** paper, to verify a load-bearing constraint (a method actually used, a score actually reported, an affiliation, what a paper compares to).
-  Use it to settle a specific doubt, not on everything.
-
-- CLI: **`firecrawl search <query> --categories research`**
-  MCP: **`firecrawl_search(query, categories: ["research"])`**
-  **Not this index.** This is a _website_ filter: it restricts a normal web search to a short list of research-affiliated domains — the list does include `pubmed.ncbi.nlm.nih.gov`, `biorxiv.org`, `medrxiv.org`, and `arxiv.org` alongside publisher sites — and returns page results in a `research` group beside `web`, each with `url`, `title`, `description` (the matched passage), `position`, and `category: "research"` — web results carry no `category`, so that is the field to key on when merging.
-  So it reaches those sites' **web pages**; what it does not do is query their **paper records** in this index. For a paper-finding task, use `firecrawl research search-papers` and its siblings above.
-
-- CLI: **`firecrawl search <query>` / `firecrawl scrape <url>`**
-  MCP: **`firecrawl_search(query)` / `firecrawl_scrape(url)`**
-  General **web** search and page fetch, for facts that don't live in paper abstracts: benchmark **leaderboards**, rankings, "who scores best / is largest / is most used."
-  Find the ranking on the web, then map the top entries back to papers with `search-papers`.
+A successful `search-papers` response is `{success, results}`. Each hit carries `paperId`, `primaryId` (`pmid:`, `pmcid:`, `doi:`, or `arxiv:`), `ids`, `title`, `abstract`, and `score`.
 
 **Done when:** the answer is a cited paper set (or the one named paper), each kept or dropped against a verified constraint, with `search-papers` as the first move unless the query already named an id.
 
-## Match the approach to the query
+## Tips
 
-- **Single _named_ paper** ("the Qwen3 report") → one `search-papers`, done. This is the only case that truly wants exactly one paper.
-- **Paper by description / by method or technique** ("the paper that introduced X", "training-free N-gram detection of AI text") → find the best match, then assume there's a _family_: expand with `related-papers` and **include the closely-related methods/papers too**. Even when one paper is the exact literal match, surface and keep its neighbors — don't narrow to the single best hit and reason the rest out. Only treat it as one-answer if the query names a specific paper.
-- **Enumeration / method-family** ("papers that do X", "alternatives to Adam", "benchmarks for Y") → the answer is a _set_, and this is where `related-papers` earns its keep: expand several strong anchors with `mode=similar`, re-seed from new strong hits. One search is never enough here.
-- **Exhibiting** ("papers that _use_ / exhibit property P") → the relevant papers apply P but their abstracts may not describe it. Go from P's defining paper outward via `citers`/`references`, and use `read-paper` to confirm a candidate actually uses P.
-- **Superlative / leaderboard** ("best on benchmark X", "largest", "most popular") → the ranking lives on **leaderboards / the web**, not in any single abstract. Use `firecrawl search` / `firecrawl scrape` to find the benchmark's leaderboard or rankings, read off the top models/papers, then `search-papers` each to get its paper. As a fallback, search the benchmark and `read-paper` candidates for reported numbers.
-- **Org / author filtered** ("from \<org\>", "by \<author\>") → topical match isn't enough; verify the affiliation/authorship (metadata or `read-paper`) before keeping a paper.
-- **Compare-against** ("what does paper X benchmark against / build on") → the answer is _inside_ paper X: `read-paper(X, ...)` or `related-papers` with `mode=references`.
+- `search-papers` is the first move. If results look thin or all-alike, re-run with a different framing (sibling domain, rival method, dataset/benchmark name).
+- `related-papers` needs `--intent`. `mode=similar` for siblings, `citers` for who builds on the seeds, `references` for what they build on.
+- `inspect-paper` is metadata for one id. `read-paper` is in-body passages for one constraint (sample size, method, affiliation). Use it to rule a paper out, not to gatekeep.
+- `search --categories research` is a website filter. It returns pages from academic domains, not paper records in this index.
+- Named paper ("the Qwen3 report") → one `search-papers`. Method / family / "papers that do X" → expand with `related-papers` and keep neighbors.
+- Superlative / leaderboard questions live on the web: `firecrawl search` / `firecrawl scrape`, then `search-papers` each top entry.
+- PubMed, bioRxiv, and medRxiv are the largest part of the corpus. Do not send a biomedical query to the open web on the assumption the index is arXiv-only.
 
-## Principles
+## See also
 
-- **Two different features share the word "research."** The paper index is `firecrawl research` / `firecrawl_research_*`. The `categories: ["research"]` option on `firecrawl search` is a website filter — it does point web search at PubMed, bioRxiv, medRxiv, arXiv, and publisher sites, but what comes back is their web pages, not paper records. If a task is about finding papers, the tools in this skill are the ones that read the corpus.
-- **Query shape and subject field are separate.** A clinical-trial question and a machine-learning question take the same shapes above; what differs is only which source the hits come from. Don't send a biomedical or life-science query to the open web on the assumption the corpus is arXiv-only — PubMed, bioRxiv, and medRxiv are the largest part of what `search-papers` reads.
-- **When in doubt, include.** For any topic / method / comparison question, return the relevant _family_, not just the single best match. The neighboring methods are part of a good answer.
-- **Follow the literature, and keep what you find.** The seminal source, the competing methods, the close neighbors are usually a hop away — use `related-papers`, and _include_ them, not just the first hit.
-- **Verify to exclude, not to gatekeep.** Use `read-paper` to rule a paper _out_ when a hard constraint clearly fails (wrong org/author, doesn't actually report the score). When a paper is plausibly relevant, lean toward keeping it rather than demanding proof.
-- **Only drop the clearly off-topic.** Don't pad with papers you're confident are unrelated — but that's a high bar; most plausibly-relevant work should make the cut.
+- [firecrawl-search](../firecrawl-search/SKILL.md) — web pages, including `search --categories research`
+- [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — leaderboards and other non-paper pages
+- [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md) — issues, PRs, READMEs, and docs

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: firecrawl-search
 description: |
-  Web search with full page content, plus a research-paper index (PubMed, arXiv, bioRxiv, medRxiv). Use when no URL is known: finding sources, articles, news, or scientific literature.
+  Web search with full page content. Use when no URL is known: finding sources, articles, or news. For papers use firecrawl-research-index; for library, API, error, or bug questions use firecrawl-developer-index.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl-cli *)
@@ -9,7 +9,7 @@ allowed-tools:
 
 # firecrawl search
 
-Web search with optional content scraping. Returns search results as JSON, optionally with full page content. For research papers, route to [Paper search](#paper-search) (`firecrawl research`).
+Web search with optional content scraping. Returns search results as JSON, optionally with full page content.
 
 ## Quick start
 
@@ -22,73 +22,13 @@ firecrawl search "your query" --scrape -o .firecrawl/scraped.json --json
 
 # News from the past day
 firecrawl search "your query" --sources news --tbs qdr:d -o .firecrawl/news.json --json
-
-# Programming question: search GitHub issues, merged PRs, READMEs, and docs
-firecrawl search "your query" --categories developer -o .firecrawl/developer.json --json
-
-# Research papers: use the paper index (`research`, not `search --categories research`)
-firecrawl research search-papers "your query" -o .firecrawl/papers.json --json
 ```
 
 Run `firecrawl search --help` for the full option list.
 
+`--categories developer` weighs the developer index beside ordinary web results in this same call (no passage control, no index filters). `--categories research` is a website filter, not the paper index. Dedicated skills: [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md) and [firecrawl-research-index](../firecrawl-research-index/SKILL.md).
+
 **Done when:** results are saved under `.firecrawl/`, verified non-empty, processed for the request, and one feedback event is sent within the time window (unless opted out).
-
-## Developer search
-
-`--categories developer` adds an index built for coding agents. It covers GitHub
-issues, merged pull requests, repository READMEs, and curated documentation
-sites. Use it for a programming question: an error message, an API contract, a
-library behaviour, or a known bug.
-
-The hits arrive in their own `data.developer` group beside `data.web`. Each hit
-holds `url`, `title`, and `description`, where `description` is the matched
-passage. Read the passages with
-`jq -r '.data.developer[] | .url, .description' .firecrawl/developer.json`.
-
-The dedicated `firecrawl developer` command searches only that index and keeps
-the full matched passages:
-
-```bash
-# Developer search only, with full passages
-firecrawl developer "your query" --limit 10 -o .firecrawl/developer.json --json
-```
-
-Each result holds `id`, `type` (`issue`, `pull_request`, `readme`, `doc`),
-`url`, `title`, and `passages`. Read them with
-`jq -r '.results[] | .url, .passages[].text' .firecrawl/developer.json`.
-
-## Paper search
-
-For actual papers use the `firecrawl research` command group, which searches
-roughly 43M abstracts, around 90% biomedical (PubMed, bioRxiv, medRxiv) plus
-arXiv. (`search --categories research` is a website filter — it only narrows
-ordinary web results to research-affiliated sites.)
-
-Reach for it on any biomedical, clinical, or scientific-literature question —
-it replaces web-searching or scraping PubMed, bioRxiv, medRxiv, or Google
-Scholar by hand:
-
-```bash
-# Find papers by topic -- start here, and run several distinct framings
-firecrawl research search-papers "CRISPR base editing off-target effects" \
-  --limit 20 -o .firecrawl/papers.json --json
-
-# Expand from your strongest hits along the citation graph
-firecrawl research related-papers pmid:40953549 --intent "in vivo delivery" \
-  -o .firecrawl/papers-related.json --json
-
-# Verify a specific claim against the full text before you cite it
-firecrawl research read-paper pmcid:PMC12530322 --question "What was the sample size?" \
-  -o .firecrawl/paper-passages.json --json
-```
-
-Paper ids accept `pmid:`, `pmcid:`, `doi:`, and `arxiv:` forms. `inspect-paper`
-returns canonical metadata for one id. Read hits with
-`jq -r '.results[] | .primaryId, .title' .firecrawl/papers.json`.
-
-See [firecrawl](../firecrawl/SKILL.md) for how paper search fits the
-overall command routing.
 
 ## Tips
 
@@ -145,3 +85,5 @@ fi
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — scrape a specific URL
 - [firecrawl-map](../firecrawl-map/SKILL.md) — discover URLs within a site
 - [firecrawl-crawl](../firecrawl-crawl/SKILL.md) — bulk extract from a site
+- [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md) — issues, merged PRs, READMEs, and docs
+- [firecrawl-research-index](../firecrawl-research-index/SKILL.md) — published papers, not `search --categories research`

--- a/skills/firecrawl/SKILL.md
+++ b/skills/firecrawl/SKILL.md
@@ -34,6 +34,7 @@ Follow this escalation pattern:
 | --------------------------- | --------------------- | --------------------------------------------------------------- |
 | Find pages on a topic       | `search`              | No specific URL yet                                             |
 | Find research papers        | `research`            | Biomedical/clinical/scientific literature — use the paper index |
+| Answer a coding question    | `developer`           | Issues, merged PRs, READMEs, and docs — not a general web page  |
 | Get a page's content        | `scrape`              | Have a URL, page is static or JS-rendered                       |
 | Find URLs within a site     | `map`                 | Need to locate a specific subpage                               |
 | Bulk extract a site section | `crawl`               | Need many pages (e.g., all /docs/)                              |
@@ -63,7 +64,8 @@ For detailed command reference, run `firecrawl <command> --help`.
 ## When to Load References
 
 - **Searching the web or finding sources first** -> [firecrawl-search](../firecrawl-search/SKILL.md)
-- **Finding research papers (biomedical, clinical, or scientific literature; PubMed, bioRxiv, medRxiv, arXiv)** -> `firecrawl research search-papers`, documented in [firecrawl-search](../firecrawl-search/SKILL.md). Use the paper index instead of scraping PubMed or Google Scholar by hand; `search --categories research` is a website filter, not the paper index.
+- **Finding research papers (biomedical, clinical, or scientific literature; PubMed, bioRxiv, medRxiv, arXiv)** -> [firecrawl-research-index](../firecrawl-research-index/SKILL.md). Use the paper index instead of scraping PubMed or Google Scholar by hand; `search --categories research` is a website filter, not the paper index.
+- **Answering a library, API, error, or known-bug question from issues, merged PRs, READMEs, or docs** -> [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md)
 - **Scraping a known URL** -> [firecrawl-scrape](../firecrawl-scrape/SKILL.md)
 - **Finding URLs on a known site** -> [firecrawl-map](../firecrawl-map/SKILL.md)
 - **Bulk extraction from a docs section or site** -> [firecrawl-crawl](../firecrawl-crawl/SKILL.md)

--- a/skills/firecrawl/SKILL.md
+++ b/skills/firecrawl/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: firecrawl
 description: |
-  Any live-web task via the Firecrawl CLI — including ordinary web research: searching the web, reading or extracting pages, gathering sources, discovering site URLs, bulk extraction, downloading a site, change alerts, or pages needing clicks/login — web only; local files route to firecrawl-parse.
+  Any live-web task via the Firecrawl CLI — including ordinary web research: searching the web, reading or extracting pages, gathering sources, discovering site URLs, bulk extraction, downloading a site, change alerts, or pages needing clicks/login — web only; local files route to firecrawl-parse. For papers use firecrawl-research-index; for library, API, error, or bug questions use firecrawl-developer-index.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl-cli *)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1054,7 +1054,7 @@ function createSearchCommand(): Command {
 function createDeveloperCommand(): Command {
   const developerCmd = new Command('developer')
     .description(
-      'Search an index built for coding agents: GitHub issues, merged PRs, repository READMEs, and curated documentation sites. Use it for a programming question: code behaviour, a library or framework, an API contract, an error message, or a known bug. Returns ranked results with id, type, url, title, and the matched passages in markdown.'
+      'Search an index built for coding agents: issues, merged PRs, repository READMEs, and curated documentation sites. Use it for a programming question: code behaviour, a library or framework, an API contract, an error message, or a known bug. Returns ranked results with id, url, title, and the matched passages in markdown. Kind is the id prefix (doc:, issue:, pull_request:, readme:).'
     )
     .argument('<query>', 'Natural-language developer question or search phrase')
     .option(


### PR DESCRIPTION
## Why
The developer and research index skills were sitting in `firecrawl/skills`, which is the build repo. They are session skills (answer a question now), so they belong next to `firecrawl developer` and `firecrawl research`.

## Summary
- Add `firecrawl-developer-index` and `firecrawl-research-index` as standalone CLI skills, registered in the Claude plugin lists.
- Route paper and library/API questions from `firecrawl` / `firecrawl-search` to those skills instead of embedding the recipes in web search.
- Match live production shapes: developer hits use the `id` prefix for kind (no `type` field); `search-papers` hits carry `paperId`, `primaryId`, `ids`, `title`, `abstract`, and `score`.
- Companion change: those skills are removed from `firecrawl/skills` on https://github.com/firecrawl/skills/pull/11

## Test Plan
- [ ] `npx skills add firecrawl/cli@firecrawl-developer-index` and `@firecrawl-research-index` install
- [ ] `firecrawl developer "retry backoff" --limit 2 --json` results have `id`, `url`, `passages` and no `type`
- [ ] `firecrawl research search-papers "CRISPR base editing" --limit 2 --json` results have `paperId`, `primaryId`, `ids`, `title`, `abstract`, `score`
- [ ] `firecrawl developer --help` no longer claims a `type` field
- [ ] `firecrawl-search` description no longer claims paper search as its job

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `firecrawl-developer-index` and `firecrawl-research-index` as standalone session skills and makes `firecrawl-search` web-only. This clarifies routing for coding and paper queries and aligns response shapes with production.

- Registers the two skills in `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`, adds SKILL docs, and updates `firecrawl-search`/`firecrawl` docs to point to the new skills and use shorter triggers.
- Developer search behavior change: results drop the `type` field; infer kind from the `id` prefix (`doc:`, `issue:`, `pull_request:`, `readme:`). Required: update any parsers that read `type`; CLI help in `src/index.ts` now documents the prefix.
- Paper search shape is explicit: `search-papers` returns `paperId`, `primaryId`, `ids`, `title`, `abstract`, and `score`. Required: ensure clients read these fields.
- `firecrawl-search` no longer claims to hit the paper index; `--categories research` is a website filter only, and `--categories developer` just weighs developer hits in the same web call. Required: call `firecrawl research`/`firecrawl-research-index` for papers and `firecrawl-developer-index` for library/API/error/bug questions.
- Optional coordination: remove these skills from the build repo when this lands.

<sup>Written for commit 3c9202dcb5586b1b9ce1f4ecb5d0f486d9bb532f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

