### PR TITLE
release: 1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website, and search a ~43M-abstract research paper index (PubMed, bioRxiv, medRxiv, arXiv), directly from your terminal.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Releases `firecrawl-cli` 1.22.0 to ship a leaner developer search surface. Previously many filter flags were accepted; now only the search query and `--limit` are supported, so invocations using removed flags will error.

- Remove these flags from all scripts and docs: `--passages`, `--types`, `--repos`, `--sources`, `--language`, `--topic`, `--license`, `--min-stars`, `--max-stars`, `--archived`, `--fork`, `--skills-only`.
- Move scoping into the query text and keep `--limit` only if needed.

<sup>Written for commit 9f2e7f95bc1ef3b4ef9314cdcd778caee27155d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

