### PR TITLE
Point catalog sync at skills/core/

### DIFF
--- a/.github/workflows/sync-catalog.yml
+++ b/.github/workflows/sync-catalog.yml
@@ -1,6 +1,6 @@
-name: Sync CLI skills to catalog
+name: Sync core skills to catalog
 
-# Mirrors skills/ into firecrawl/skills under skills/cli/.
+# Mirrors skills/ into firecrawl/skills under skills/core/.
 # The catalog copy is a read-only mirror; PRs against it are redirected here.
 
 on:
@@ -34,18 +34,18 @@ jobs:
           ssh-key: ${{ secrets.CATALOG_DEPLOY_KEY }}
           path: catalog
 
-      - name: Sync skills/cli
+      - name: Sync skills/core
         run: |
           cd catalog
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          rm -rf skills/cli
-          mkdir -p skills/cli
-          cp -R ../cli/skills/. skills/cli/
+          rm -rf skills/core
+          mkdir -p skills/core
+          cp -R ../cli/skills/. skills/core/
 
-          cat > skills/cli/README.md <<'EOF'
-          # CLI skills (mirror)
+          cat > skills/core/README.md <<'EOF'
+          # Core skills (mirror)
 
           Mirror of [`firecrawl/cli`](https://github.com/firecrawl/cli/tree/main/skills) — do not edit here.
           PR changes against `firecrawl/cli`; CI overwrites this directory on every sync.

--- a/src/commands/skills-install.ts
+++ b/src/commands/skills-install.ts
@@ -29,8 +29,8 @@ export const ALL_SKILL_REPOS = [
 export const CATALOG_REPO = 'firecrawl/skills';
 
 /**
- * CLI skills, authored in firecrawl/cli and mirrored into the catalog under
- * skills/cli/. Selection is name-based (`--skill`), so the catalog's
+ * Core skills, authored in firecrawl/cli and mirrored into the catalog under
+ * skills/core/. Selection is name-based (`--skill`), so the catalog's
  * directory layout doesn't matter.
  */
 export const CLI_SKILLS = [


### PR DESCRIPTION
Half 1 of renaming the catalog's `skills/cli/` → `skills/core/` (the family covers the Firecrawl primitives via CLI or MCP, not just the CLI — see firecrawl/skills for the other half).

- `sync-catalog.yml` now mirrors into catalog `skills/core/` and writes a "Core skills (mirror)" README
- Updated the `skills-install.ts` doc comments; no behavior change — install selection is name-based, so skills.sh slugs and `firecrawl init` are unaffected

**Merge this first.** The sync will create `skills/core/` in the catalog alongside the old folder; the catalog PR then removes `skills/cli/` and updates the plugin manifests, so there's no window where manifest paths point at a missing directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename the catalog mirror from `skills/cli/` to `skills/core/` to reflect that these are shared core skills used by CLI and MCP. No runtime behavior changes; install selection remains name-based, so slugs and `firecrawl init` are unchanged.

- Update `.github/workflows/sync-catalog.yml` to mirror `cli/skills/` into catalog `skills/core/` and write a "Core skills (mirror)" README.
- Update doc comments in `src/commands/skills-install.ts` to reference `skills/core/` only.

**Review and rollout**
- Merge this first. The sync will create `skills/core/` alongside `skills/cli/`.
- Follow-up in the catalog will remove `skills/cli/` and update plugin manifests, avoiding any window with missing paths.
- No user or integrator actions required.

<sup>Written for commit 7a48d598b4433fde2990bd06e6fd10da021d4323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

