### PR TITLE
release: 1.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website, and search a ~43M-abstract research paper index (PubMed, bioRxiv, medRxiv, arXiv), directly from your terminal.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Version bump to publish the new `setup` subcommands (#206) to npm.

**Merge after #206** — merging this triggers `publish.yml` (npm publish of whatever is on `main`) and `release-binaries.yml`, so #206 must be on `main` first or 1.23.0 ships without the new subcommands.

New in 1.23.0:
- `firecrawl setup core` / `setup build` / `setup workflows` — one command per skill family (`setup skills` stays as an alias for `core`)
- `firecrawl setup <skill-name>` — install any single catalog skill; `firecrawl-` prefix optional (e.g. `setup developer-index`)
- Post-install auth offer: silent when a key exists, browser login via `--browser` or interactive confirm, one-line hint in non-interactive runs (never blocks agents/CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.23.0 of `firecrawl-cli` to ship new setup subcommands and a non‑blocking post‑install auth flow. This PR triggers npm publish, so merge order matters.

- Behavior changes in 1.23.0:
  - Setup commands: previously `setup skills` only; now `setup core`, `setup build`, and `setup workflows` (with `setup skills` kept as an alias for `core`).
  - Single-skill install: add `setup <skill-name>`; the `firecrawl-` prefix is optional (e.g., `setup developer-index`).
  - Post-install auth: previously could prompt and block; now silent if a key exists, supports optional browser login via `--browser` or interactive confirm, and prints a one-line hint in non-interactive runs; never blocks agents/CI.

- Review and rollout:
  - Merge only after #206 is on `main`; otherwise 1.23.0 will publish without the new subcommands.
  - This PR only bumps the version; merging triggers `publish.yml` (npm publish of `main`) and `release-binaries.yml`.

<sup>Written for commit c5bd8e9f8ef55dd40839c48a4633c545326efaa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

