### PR TITLE
Fix skill-scoped installs installing the whole catalog

### DIFF
--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -54,11 +54,11 @@ describe('handleInitCommand', () => {
     });
 
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --all --yes ${cliSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes ${cliSkillFlags}`,
       expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
     );
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --all --yes ${workflowSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes ${workflowSkillFlags}`,
       expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
     );
     // Build skills are intentionally no longer installed by init.

--- a/src/__tests__/commands/setup.test.ts
+++ b/src/__tests__/commands/setup.test.ts
@@ -89,7 +89,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('skills', {});
 
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --all ${cliSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes ${cliSkillFlags}`,
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -98,7 +98,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('skills', { agent: 'cursor' });
 
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --agent cursor ${cliSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes --agent cursor ${cliSkillFlags}`,
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -107,7 +107,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('core', {});
 
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --all ${cliSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes ${cliSkillFlags}`,
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -116,7 +116,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('build', {});
 
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --all ${buildSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes ${buildSkillFlags}`,
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -156,7 +156,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('firecrawl-developer-index', {});
 
     expect(execSync).toHaveBeenCalledWith(
-      'npx -y skills add firecrawl/skills --full-depth --global --all --skill firecrawl-developer-index',
+      'npx -y skills add firecrawl/skills --full-depth --global --yes --skill firecrawl-developer-index',
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -165,7 +165,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('developer-index', {});
 
     expect(execSync).toHaveBeenCalledWith(
-      'npx -y skills add firecrawl/skills --full-depth --global --all --skill firecrawl-developer-index',
+      'npx -y skills add firecrawl/skills --full-depth --global --yes --skill firecrawl-developer-index',
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -174,7 +174,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('build', {});
 
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --all ${buildSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes ${buildSkillFlags}`,
       expect.objectContaining({ stdio: 'inherit' })
     );
 
@@ -182,7 +182,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('firecrawl-build', {});
 
     expect(execSync).toHaveBeenCalledWith(
-      'npx -y skills add firecrawl/skills --full-depth --global --all --skill firecrawl-build',
+      'npx -y skills add firecrawl/skills --full-depth --global --yes --skill firecrawl-build',
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -191,7 +191,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand('workflows', {});
 
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --all ${workflowSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes ${workflowSkillFlags}`,
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -232,7 +232,7 @@ describe('handleSetupCommand', () => {
     await handleSetupCommand(undefined, { yes: true });
 
     expect(execSync).toHaveBeenCalledWith(
-      `npx -y skills add firecrawl/skills --full-depth --global --all --yes ${cliSkillFlags}`,
+      `npx -y skills add firecrawl/skills --full-depth --global --yes ${cliSkillFlags}`,
       expect.objectContaining({ stdio: 'inherit' })
     );
     expect(execFileSync).toHaveBeenCalledWith(

--- a/src/commands/skills-install.ts
+++ b/src/commands/skills-install.ts
@@ -139,12 +139,18 @@ export function buildSkillsInstallArgs(
     args.push('--global');
   }
 
-  const installToAllAgents = options.agent ? false : (options.all ?? true);
+  // `skills add --all` means "ALL skills to all agents" and overrides any
+  // --skill filter, so a skill-scoped install must never pass it. Scoped
+  // installs use --yes instead: same promptless install to every detected
+  // agent, but the --skill list is respected.
+  const skillScoped = Boolean(options.skills?.length);
+  const installToAllAgents =
+    !skillScoped && (options.agent ? false : (options.all ?? true));
   if (installToAllAgents) {
     args.push('--all');
   }
 
-  if (options.yes) {
+  if (options.yes || skillScoped) {
     args.push('--yes');
   }
 


### PR DESCRIPTION
**Bug** (user-reported): `npx -y firecrawl-cli@latest setup developer-index` installed all 33 catalog skills instead of one.

**Cause**: `buildSkillsInstallArgs` passes `--all` whenever no `--agent` is given — but the skills CLI defines `--all` as "install **all skills** to all agents without prompts", which silently overrides the `--skill` filter. Reproduced with the raw skills CLI: `--all --skill firecrawl-developer-index` → 33 skills; `--yes --skill firecrawl-developer-index` → 1 skill.

**Scope**: worse than the new single-skill command — every skill-scoped install had this: `setup core` (12→33), `setup build` (5→33), `setup workflows` (16→33), and `init`'s selections. It went unnoticed because extra skills fail quietly; 1→33 made it obvious.

**Fix**: skill-scoped installs never pass `--all`; they pass `--yes` instead — same promptless install to every detected agent, with the `--skill` list respected. Whole-repo installs are unchanged.

**Verified**: built CLI in a fresh $HOME — `setup developer-index` installs exactly 1 skill, `setup build` exactly 5; 431/431 tests pass (expectations updated), tsc + prettier clean.

Needs a patch release to ship — see the follow-up `release: 1.23.1` PR (merge that after this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes skill-scoped installs that were installing the entire catalog by incorrectly passing `--all`. Skill-scoped installs now pass `--yes`, which respects the `--skill` filter; whole-repo installs are unchanged.

- Updates buildSkillsInstallArgs: detect skill-scoped via presence of `--skill`; never pass `--all` for skill-scoped installs; pass `--yes` for skill-scoped or when explicitly requested; preserve agent handling.
- Updates tests to expect `--yes` instead of `--all` for skill-scoped paths; verified that `setup developer-index` installs 1 skill and `setup build` installs 5.
- Impact: `setup core/build/workflows`, `setup <skill>`, and `init` selections now install only the intended skills. No migration required. Ship as a patch release (`1.23.1`) for `firecrawl-cli`.

<sup>Written for commit d53a939c4151cd6af40a77c45566bc8f856b714a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

