### PR TITLE
release: 1.23.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-cli",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Command-line interface for Firecrawl. Scrape, crawl, and extract data from any website, and search a ~43M-abstract research paper index (PubMed, bioRxiv, medRxiv, arXiv), directly from your terminal.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Patch release for #209 — skill-scoped installs (`setup core/build/workflows/<skill>`, `init` selections) no longer install the entire catalog.

**Merge after #209**, then dispatch Release Binaries once (its path filter fires on this package.json change, so it should run automatically this time — verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `firecrawl-cli` 1.23.1 to ship skill‑scoped installs. Previously, `setup core/build/workflows/<skill>` and `init` selections installed the entire catalog; now they install only the selected skills, reducing install time and footprint.

- Merge after #209; this PR only bumps the `package.json` version.
- Verify the Release Binaries workflow auto-triggers on the version change; if it doesn’t, dispatch it once.

<sup>Written for commit 69b8c69a10ecc3ea2408946cc2050a8bbb5bf680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

