### PR TITLE
Correct skill installation and monitoring cost

### DIFF
--- a/skills/firecrawl-monitor/SKILL.md
+++ b/skills/firecrawl-monitor/SKILL.md
@@ -63,6 +63,7 @@ Read [goals.md](goals.md) when writing or refining `--goal` (and `--queries` for
 
 ## Constraints & tips
 
+- Each check uses credits for its underlying scrape, crawl, or search, plus optional judging. See [Monitoring pricing](https://docs.firecrawl.dev/features/monitoring#pricing).
 - Minimum schedule interval is **5 minutes**. Monitoring is **not available for zero-data-retention teams**.
 - **Prefer one monitor over repeated one-off scrapes** whenever the user wants the same URL checked more than once.
 - **Silence temporarily with `update --state paused`**; reserve `delete` for monitors that are permanently done. (`--state` is an update flag; `--status` is the global CLI status flag.)

--- a/skills/firecrawl/rules/install.md
+++ b/skills/firecrawl/rules/install.md
@@ -15,7 +15,7 @@ description: |
 npx -y firecrawl-cli@latest init -y --browser
 ```
 
-This installs `firecrawl-cli` globally, authenticates via browser, and installs core, build, and workflow skills.
+This installs `firecrawl-cli` globally, authenticates via browser, and installs core and workflow skills. Build skills are a separate step: `firecrawl setup build`.
 
 This setup is safe to re-run when the CLI is missing, stale, or only partially configured.
 
@@ -31,6 +31,7 @@ To install skills manually:
 
 ```bash
 firecrawl setup skills
+firecrawl setup build
 firecrawl setup workflows
 ```
 

--- a/src/commands/skills-install.ts
+++ b/src/commands/skills-install.ts
@@ -8,9 +8,10 @@
  *
  * - firecrawl/firecrawl-workflows: outcome-focused Firecrawl workflow skills
  *
- * `firecrawl init` installs both groups by default. `firecrawl setup skills`
- * installs core/build skills, and `firecrawl setup workflows` installs workflow
- * skills.
+ * `firecrawl init` installs core CLI skills and workflow skills.
+ * `firecrawl setup skills` (alias `setup core`) installs core CLI skills,
+ * `firecrawl setup build` installs build skills, and
+ * `firecrawl setup workflows` installs workflow skills.
  */
 export const SKILL_REPOS = ['firecrawl/cli', 'firecrawl/skills'] as const;
 


### PR DESCRIPTION
## Why

The bundled install guidance says `init` installs build skills, but build skills require a separate setup step. The monitor skill also omits the published cost model for recurring checks.

## Summary

- State that `init` installs the CLI, core skills, and workflow skills.
- Document `firecrawl setup build` as the separate build-skill step.
- Add one sentence linking monitoring checks to their underlying operation and optional judging costs.

## Test Plan

- [x] `pnpm test`, 433 passing tests
- [x] `pnpm run type-check`
- [x] `pnpm run format:check`
- [x] `pnpm run build`
- [x] `git diff --check`
