### PR TITLE
fix: bound developer passage rendering

### DIFF
--- a/src/__tests__/commands/developer.test.ts
+++ b/src/__tests__/commands/developer.test.ts
@@ -179,6 +179,60 @@ describe('handleDeveloperSearchCommand', () => {
       expect(passageBlock).toHaveLength(40);
     });
 
+    it('keeps citation line breaks inside the passage line budget', async () => {
+      const passage = Array.from(
+        { length: 50 },
+        (_, index) => `Line ${index + 1}`
+      ).join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          {
+            ...sampleResult,
+            passages: [
+              {
+                text: passage,
+                citation_url: 'https://example.com/one\r\ntwo\nthree',
+              },
+            ],
+          },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+      expect(passageBlock.at(-2)).toBe(
+        '… (12 more lines; use --json for the full passage)'
+      );
+      expect(passageBlock.at(-1)).toBe(
+        'Citation: https://example.com/one two three'
+      );
+    });
+
+    it('normalizes and caps passages with lone carriage-return lines', async () => {
+      const passage = Array.from(
+        { length: 50 },
+        (_, index) => `Line ${index + 1}  `
+      ).join('\r');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+      expect(passageBlock[0]).toBe('Line 1');
+      expect(passageBlock.at(-1)).toBe(
+        '… (11 more lines; use --json for the full passage)'
+      );
+    });
+
     it('keeps a long fenced passage balanced within the line cap', async () => {
       const passage = [
         '```rust',
@@ -236,6 +290,160 @@ describe('handleDeveloperSearchCommand', () => {
       const passageBlock = content.split('\n').slice(3);
       expect(passageBlock).toHaveLength(40);
       expect(passageBlock.at(-2)).toBe(close);
+      expect(passageBlock.at(-1)).toContain('use --json');
+    });
+
+    it('expands tab-padded list indentation for a synthetic closer', async () => {
+      const passage = [
+        '-\t```text',
+        ...Array.from({ length: 50 }, (_, index) => `    code ${index}`),
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+      expect(passageBlock.at(-2)).toBe('    ```');
+      expect(passageBlock.at(-1)).toContain('use --json');
+    });
+
+    it('matches a tab-padded list opener to a column-indented closer', async () => {
+      const passage = [
+        '-\t```text',
+        ...Array.from({ length: 10 }, (_, index) => `    code ${index}`),
+        '    ```',
+        ...Array.from({ length: 40 }, (_, index) => `prose ${index}`),
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+      expect(passageBlock.filter((line) => line === '    ```')).toHaveLength(1);
+      expect(passageBlock).toContain('prose 26');
+    });
+
+    it('accepts valid closing-fence indentation that differs from the opener', async () => {
+      const passage = [
+        ' ```text',
+        ...Array.from({ length: 10 }, (_, index) => `code ${index}`),
+        '  ```',
+        ...Array.from({ length: 40 }, (_, index) => `prose ${index}`),
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock.filter((line) => line.trim() === '```')).toHaveLength(
+        1
+      );
+      expect(passageBlock).toContain('prose 26');
+      expect(passageBlock.at(-1)).toContain('use --json');
+    });
+
+    it('preserves matching indentation on a synthetic closing fence', async () => {
+      const passage = [
+        '  ```text',
+        ...Array.from({ length: 50 }, (_, index) => `  code ${index}`),
+        '  ```',
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock[0]).toBe('  ```text');
+      expect(passageBlock.at(-2)).toBe('  ```');
+    });
+
+    it('accepts a blockquote closer with different optional spacing', async () => {
+      const passage = [
+        '> ```text',
+        ...Array.from({ length: 10 }, (_, index) => `> code ${index}`),
+        '>```',
+        ...Array.from({ length: 40 }, (_, index) => `prose ${index}`),
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(
+        passageBlock.filter((line) => line.trim() === '>```')
+      ).toHaveLength(1);
+      expect(passageBlock).toContain('prose 26');
+    });
+
+    it('does not parse a ten-digit ordered marker as a list container', async () => {
+      const passage = [
+        '1234567890. ```text',
+        ...Array.from({ length: 50 }, (_, index) => `prose ${index}`),
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+      expect(passageBlock.filter((line) => line.trim() === '```')).toHaveLength(
+        0
+      );
+      expect(passageBlock.at(-1)).toContain('use --json');
+    });
+
+    it('does not treat non-Markdown whitespace as a fence closer', async () => {
+      const passage = [
+        '```text',
+        'code before invalid closer',
+        '```\v',
+        ...Array.from({ length: 50 }, (_, index) => `code ${index}`),
+        '```',
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+      expect(passageBlock.at(-2)).toBe('```');
       expect(passageBlock.at(-1)).toContain('use --json');
     });
 

--- a/src/__tests__/commands/developer.test.ts
+++ b/src/__tests__/commands/developer.test.ts
@@ -239,6 +239,29 @@ describe('handleDeveloperSearchCommand', () => {
       expect(passageBlock.at(-1)).toContain('use --json');
     });
 
+    it('does not close a quoted fence on list-prefixed code content', async () => {
+      const passage = [
+        '> ```text',
+        ...Array.from({ length: 10 }, (_, index) => `> code ${index}`),
+        '> - ```',
+        ...Array.from({ length: 40 }, (_, index) => `> more code ${index}`),
+        '> ```',
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toContain('> - ```');
+      expect(passageBlock.at(-2)).toBe('> ```');
+      expect(passageBlock.at(-1)).toContain('use --json');
+    });
+
     it('renders every passage without a passage-count cap', async () => {
       const passages = Array.from({ length: 45 }, (_, index) => ({
         text: `unique passage ${index + 1}`,

--- a/src/__tests__/commands/developer.test.ts
+++ b/src/__tests__/commands/developer.test.ts
@@ -143,6 +143,82 @@ describe('handleDeveloperSearchCommand', () => {
       expect(content).toContain('rust: not indexed');
     });
 
+    it('collapses blank runs and caps each passage at 40 rendered lines', async () => {
+      const passage = [
+        'First line.  ',
+        '',
+        '',
+        '',
+        ...Array.from({ length: 50 }, (_, index) => `Line ${index + 2}`),
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          {
+            ...sampleResult,
+            passages: [
+              {
+                text: passage,
+                citation_url: 'https://example.com/citation',
+              },
+            ],
+          },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      expect(content).not.toContain('First line.  ');
+      expect(content).not.toContain('\n\n\n');
+      expect(content).toContain(
+        '… (14 more lines; use --json for the full passage)'
+      );
+      expect(content).not.toContain('Line 39\n');
+      expect(content).toContain('Citation: https://example.com/citation');
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+    });
+
+    it('keeps a long fenced passage balanced within the line cap', async () => {
+      const passage = [
+        '```rust',
+        ...Array.from(
+          { length: 50 },
+          (_, index) => `let value_${index} = ${index};`
+        ),
+        '```',
+      ].join('\n');
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+      expect(passageBlock.filter((line) => line === '```')).toHaveLength(1);
+      expect(passageBlock.at(-2)).toBe('```');
+      expect(passageBlock.at(-1)).toContain('use --json');
+    });
+
+    it('renders every passage without a passage-count cap', async () => {
+      const passages = Array.from({ length: 45 }, (_, index) => ({
+        text: `unique passage ${index + 1}`,
+      }));
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([{ ...sampleResult, passages }])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      for (const passage of passages) expect(content).toContain(passage.text);
+      expect(content.split('\n---\n')).toHaveLength(45);
+    });
+
     it('prints a result URL only when its id does not contain it', async () => {
       const duplicateUrl = 'https://docs.rs/tokio/latest/tokio';
       mockHttpGet.mockResolvedValue(

--- a/src/__tests__/commands/developer.test.ts
+++ b/src/__tests__/commands/developer.test.ts
@@ -204,6 +204,41 @@ describe('handleDeveloperSearchCommand', () => {
       expect(passageBlock.at(-1)).toContain('use --json');
     });
 
+    it.each([
+      {
+        name: 'block quote',
+        passage: [
+          '> ```rust',
+          ...Array.from({ length: 50 }, (_, index) => `> let value_${index};`),
+          '> ```',
+        ].join('\n'),
+        close: '> ```',
+      },
+      {
+        name: 'list item',
+        passage: [
+          '- ```rust',
+          ...Array.from({ length: 50 }, (_, index) => `  let value_${index};`),
+          '  ```',
+        ].join('\n'),
+        close: '  ```',
+      },
+    ])('keeps a long $name fence balanced', async ({ passage, close }) => {
+      mockHttpGet.mockResolvedValue(
+        mockDeveloperResponse([
+          { ...sampleResult, passages: [{ text: passage }] },
+        ])
+      );
+
+      await handleDeveloperSearchCommand({ query: 'tokio spawn_blocking' });
+
+      const [content] = vi.mocked(writeOutput).mock.calls[0] as [string];
+      const passageBlock = content.split('\n').slice(3);
+      expect(passageBlock).toHaveLength(40);
+      expect(passageBlock.at(-2)).toBe(close);
+      expect(passageBlock.at(-1)).toContain('use --json');
+    });
+
     it('renders every passage without a passage-count cap', async () => {
       const passages = Array.from({ length: 45 }, (_, index) => ({
         text: `unique passage ${index + 1}`,

--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -47,8 +47,8 @@ const MAX_RENDERED_PASSAGE_LINES = 40;
 function normalizedPassageLines(text: string | undefined): string[] {
   const lines: string[] = [];
   let blank = false;
-  for (const rawLine of (text ?? '').split(/\r?\n/)) {
-    const line = rawLine.trimEnd();
+  for (const rawLine of (text ?? '').split(/\r\n|\r|\n/)) {
+    const line = rawLine.replace(/[ \t]+$/, '');
     if (line.length === 0) {
       if (lines.length > 0 && !blank) lines.push('');
       blank = true;
@@ -61,30 +61,66 @@ function normalizedPassageLines(text: string | undefined): string[] {
   return lines;
 }
 
+type FenceContainerPart =
+  | { kind: 'quote' }
+  | { kind: 'indent'; column: number };
+
+function advanceMarkdownColumn(column: number, text: string): number {
+  for (const character of text) {
+    column = character === '\t' ? column + (4 - (column % 4)) : column + 1;
+  }
+  return column;
+}
+
+function consumeIndentToColumn(
+  text: string,
+  column: number,
+  target: number
+): { rest: string; column: number } | null {
+  let index = 0;
+  while (column < target) {
+    const character = text[index];
+    if (character !== ' ' && character !== '\t') return null;
+    column = advanceMarkdownColumn(column, character);
+    if (column > target) return null;
+    index += 1;
+  }
+  return column === target ? { rest: text.slice(index), column } : null;
+}
+
 interface OpenFence {
   marker: '`' | '~';
   length: number;
+  container: FenceContainerPart[];
   closingPrefix: string;
 }
 
-function fenceCandidate(line: string): {
+function openingFenceCandidate(line: string): {
   run: string;
   tail: string;
+  container: FenceContainerPart[];
   closingPrefix: string;
 } | null {
   let rest = line;
+  const container: FenceContainerPart[] = [];
   let closingPrefix = '';
+  let column = 0;
   while (true) {
-    const quote = rest.match(/^( {0,3}>[ \t]?)/);
+    const quote = rest.match(/^( {0,3}>)[ \t]?/);
     if (quote) {
-      rest = rest.slice(quote[1].length);
-      closingPrefix += quote[1];
+      rest = rest.slice(quote[0].length);
+      container.push({ kind: 'quote' });
+      closingPrefix += quote[0];
+      column = advanceMarkdownColumn(column, quote[0]);
       continue;
     }
-    const list = rest.match(/^( {0,3}(?:[-+*]|\d+[.)])[ \t]+)/);
+    const list = rest.match(/^( {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+)/);
     if (list) {
       rest = rest.slice(list[1].length);
-      closingPrefix += ' '.repeat(list[1].length);
+      const target = advanceMarkdownColumn(column, list[1]);
+      container.push({ kind: 'indent', column: target });
+      closingPrefix += ' '.repeat(target - column);
+      column = target;
       continue;
     }
     break;
@@ -94,30 +130,60 @@ function fenceCandidate(line: string): {
     ? {
         run: match[2],
         tail: match[3],
+        container,
         closingPrefix: closingPrefix + match[1],
       }
     : null;
+}
+
+function closingFenceCandidate(
+  line: string,
+  container: FenceContainerPart[]
+): { run: string; tail: string } | null {
+  let rest = line;
+  let column = 0;
+  for (const part of container) {
+    if (part.kind === 'quote') {
+      const quote = rest.match(/^( {0,3}>)[ \t]?/);
+      if (!quote) return null;
+      rest = rest.slice(quote[0].length);
+      column = advanceMarkdownColumn(column, quote[0]);
+    } else {
+      const indent = consumeIndentToColumn(rest, column, part.column);
+      if (!indent) return null;
+      rest = indent.rest;
+      column = indent.column;
+    }
+  }
+  const match = rest.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+  return match ? { run: match[1], tail: match[2] } : null;
 }
 
 function observeFence(
   line: string,
   open: OpenFence | undefined
 ): OpenFence | undefined {
-  const candidate = fenceCandidate(line);
-  if (!candidate) return open;
-  const { run, tail: rawTail, closingPrefix } = candidate;
-  const marker = run[0] as OpenFence['marker'];
-  const tail = rawTail.trim();
   if (open) {
+    const candidate = closingFenceCandidate(line, open.container);
+    if (!candidate) return open;
+    const marker = candidate.run[0] as OpenFence['marker'];
     return marker === open.marker &&
-      run.length >= open.length &&
-      tail === '' &&
-      closingPrefix === open.closingPrefix
+      candidate.run.length >= open.length &&
+      /^[ \t]*$/.test(candidate.tail)
       ? undefined
       : open;
   }
+  const candidate = openingFenceCandidate(line);
+  if (!candidate) return undefined;
+  const marker = candidate.run[0] as OpenFence['marker'];
+  const tail = candidate.tail.trim();
   if (marker === '`' && tail.includes('`')) return undefined;
-  return { marker, length: run.length, closingPrefix };
+  return {
+    marker,
+    length: candidate.run.length,
+    container: candidate.container,
+    closingPrefix: candidate.closingPrefix,
+  };
 }
 
 function cappedPassageLines(lines: string[], capacity: number): string[] {
@@ -160,9 +226,10 @@ function cappedPassageLines(lines: string[], capacity: number): string[] {
 function fmtPassage(
   passage: Partial<DeveloperItem['passages'][number]>
 ): string {
-  const citation = passage.citation_url
-    ? `Citation: ${passage.citation_url}`
-    : undefined;
+  const citationUrl = passage.citation_url
+    ?.replace(/\r\n|\r|\n/g, ' ')
+    .replace(/[ \t]+$/, '');
+  const citation = citationUrl ? `Citation: ${citationUrl}` : undefined;
   const metadataLines = citation ? 1 : 0;
   const lines = cappedPassageLines(
     normalizedPassageLines(passage.text),
@@ -186,7 +253,7 @@ function fmtResult(item: DeveloperItem): string {
     .map(fmtPassage)
     .filter((passage) => passage.length > 0)
     .join('\n---\n')
-    .trim();
+    .trimEnd();
   lines.push(body || '(no content)');
   return lines.join('\n');
 }

--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -64,24 +64,57 @@ function normalizedPassageLines(text: string | undefined): string[] {
 interface OpenFence {
   marker: '`' | '~';
   length: number;
+  closingPrefix: string;
+}
+
+function fenceCandidate(line: string): {
+  run: string;
+  tail: string;
+  closingPrefix: string;
+} | null {
+  let rest = line;
+  let closingPrefix = '';
+  while (true) {
+    const quote = rest.match(/^( {0,3}>[ \t]?)/);
+    if (quote) {
+      rest = rest.slice(quote[1].length);
+      closingPrefix += quote[1];
+      continue;
+    }
+    const list = rest.match(/^( {0,3}(?:[-+*]|\d+[.)])[ \t]+)/);
+    if (list) {
+      rest = rest.slice(list[1].length);
+      closingPrefix += ' '.repeat(list[1].length);
+      continue;
+    }
+    break;
+  }
+  const match = rest.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
+  return match
+    ? {
+        run: match[2],
+        tail: match[3],
+        closingPrefix: closingPrefix + match[1],
+      }
+    : null;
 }
 
 function observeFence(
   line: string,
   open: OpenFence | undefined
 ): OpenFence | undefined {
-  const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
-  if (!match) return open;
-  const run = match[1];
+  const candidate = fenceCandidate(line);
+  if (!candidate) return open;
+  const { run, tail: rawTail, closingPrefix } = candidate;
   const marker = run[0] as OpenFence['marker'];
-  const tail = match[2].trim();
+  const tail = rawTail.trim();
   if (open) {
     return marker === open.marker && run.length >= open.length && tail === ''
       ? undefined
       : open;
   }
   if (marker === '`' && tail.includes('`')) return undefined;
-  return { marker, length: run.length };
+  return { marker, length: run.length, closingPrefix };
 }
 
 function cappedPassageLines(lines: string[], capacity: number): string[] {
@@ -107,7 +140,10 @@ function cappedPassageLines(lines: string[], capacity: number): string[] {
     // A passage can itself begin with a long fence. Keep a bounded preview and
     // render its closing marker before the notice.
     sourceLines = contentCapacity - 1;
-    kept = [...lines.slice(0, sourceLines), open.marker.repeat(open.length)];
+    kept = [
+      ...lines.slice(0, sourceLines),
+      `${open.closingPrefix}${open.marker.repeat(open.length)}`,
+    ];
   } else {
     sourceLines = contentCapacity;
     kept = lines.slice(0, sourceLines);

--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -42,6 +42,97 @@ function idEncodesUrl(id: string | undefined, url: string): boolean {
   return id === url || id?.endsWith(`:${url}`) === true;
 }
 
+const MAX_RENDERED_PASSAGE_LINES = 40;
+
+function normalizedPassageLines(text: string | undefined): string[] {
+  const lines: string[] = [];
+  let blank = false;
+  for (const rawLine of (text ?? '').split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (line.length === 0) {
+      if (lines.length > 0 && !blank) lines.push('');
+      blank = true;
+    } else {
+      lines.push(line);
+      blank = false;
+    }
+  }
+  while (lines.at(-1) === '') lines.pop();
+  return lines;
+}
+
+interface OpenFence {
+  marker: '`' | '~';
+  length: number;
+}
+
+function observeFence(
+  line: string,
+  open: OpenFence | undefined
+): OpenFence | undefined {
+  const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+  if (!match) return open;
+  const run = match[1];
+  const marker = run[0] as OpenFence['marker'];
+  const tail = match[2].trim();
+  if (open) {
+    return marker === open.marker && run.length >= open.length && tail === ''
+      ? undefined
+      : open;
+  }
+  if (marker === '`' && tail.includes('`')) return undefined;
+  return { marker, length: run.length };
+}
+
+function cappedPassageLines(lines: string[], capacity: number): string[] {
+  if (lines.length <= capacity) return lines;
+
+  // Reserve one line for the truncation notice. Prefer the last boundary that
+  // is outside a fenced block, so a terminal cap does not recreate the old
+  // character-slice bug that left Markdown fences open.
+  const contentCapacity = capacity - 1;
+  let open: OpenFence | undefined;
+  let lastSafe = 0;
+  for (let index = 0; index < contentCapacity; index += 1) {
+    open = observeFence(lines[index], open);
+    if (!open) lastSafe = index + 1;
+  }
+
+  let kept: string[];
+  let sourceLines: number;
+  if (lastSafe > 0) {
+    kept = lines.slice(0, lastSafe);
+    sourceLines = lastSafe;
+  } else if (open && contentCapacity >= 2) {
+    // A passage can itself begin with a long fence. Keep a bounded preview and
+    // render its closing marker before the notice.
+    sourceLines = contentCapacity - 1;
+    kept = [...lines.slice(0, sourceLines), open.marker.repeat(open.length)];
+  } else {
+    sourceLines = contentCapacity;
+    kept = lines.slice(0, sourceLines);
+  }
+  kept.push(
+    `… (${lines.length - sourceLines} more lines; use --json for the full passage)`
+  );
+  return kept;
+}
+
+function fmtPassage(
+  passage: Partial<DeveloperItem['passages'][number]>
+): string {
+  const citation = passage.citation_url
+    ? `Citation: ${passage.citation_url}`
+    : undefined;
+  const metadataLines = citation ? 1 : 0;
+  const lines = cappedPassageLines(
+    normalizedPassageLines(passage.text),
+    MAX_RENDERED_PASSAGE_LINES - metadataLines
+  );
+  if (citation) lines.push(citation);
+  return lines.join('\n');
+}
+
 function fmtResult(item: DeveloperItem): string {
   // The wire carries no type field; the artifact kind is the id prefix
   // (doc:, issue:, pull_request:, readme:).
@@ -53,15 +144,8 @@ function fmtResult(item: DeveloperItem): string {
   if (item.url && !idEncodesUrl(item.id, item.url)) lines.push(item.url);
   if (item.license) lines.push(fmtLicense(item.license));
   const body = (item.passages ?? [])
-    .map((passage) =>
-      [
-        passage.text,
-        passage.citation_url && `Citation: ${passage.citation_url}`,
-      ]
-        .filter(Boolean)
-        .join('\n')
-    )
-    .filter((passage) => passage.trim().length > 0)
+    .map(fmtPassage)
+    .filter((passage) => passage.length > 0)
     .join('\n---\n')
     .trim();
   lines.push(body || '(no content)');

--- a/src/commands/developer.ts
+++ b/src/commands/developer.ts
@@ -109,7 +109,10 @@ function observeFence(
   const marker = run[0] as OpenFence['marker'];
   const tail = rawTail.trim();
   if (open) {
-    return marker === open.marker && run.length >= open.length && tail === ''
+    return marker === open.marker &&
+      run.length >= open.length &&
+      tail === '' &&
+      closingPrefix === open.closingPrefix
       ? undefined
       : open;
   }


### PR DESCRIPTION
## Summary
- collapse blank-line runs and remove spaces or tabs at line ends in human-readable `firecrawl developer` passages
- cap each rendered passage at 40 lines, including the truncation notice and citation metadata
- cap outside Markdown fenced blocks; bounded fence previews get a matching synthetic closer
- handle valid closer indentation independently from its Markdown container and reject non-Markdown suffix whitespace
- retain every passage returned by the server
- keep `--json` and `--pretty` output complete

## Merge order
Merge this after [firecrawl/search#1007](https://github.com/firecrawl/search/pull/1007), which performs the required server-side cleanup for existing indexed passages.

## Regression coverage
- blank-run collapse, trailing-space cleanup, and lone-CR line endings
- exact 40-line cap with citation metadata, including multiline citation input
- all 45 passages render without a passage-count cap
- quoted/list-container fences
- valid closer indentation that differs from the opener
- matching indentation on synthetic closers
- blockquote closer spacing, tab-expanded list padding, and the nine-digit ordered-list limit
- vertical-tab fence suffixes do not close a fence
- JSON output remains unchanged

## Measurement
Exact-head (`82297f9694673f0e3f93553aa597aa4dd5be9f4b`) offline replay of frozen server responses for 100 deterministic Flint GT queries, every fifth row from the 500-row corpus. Both renderers receive the same 1,502 passages.

| Metric | Before | After |
|---|---:|---:|
| passages retained | 1,502 | **1,502** |
| total passage lines | 33,389 | **24,989** |
| max lines per passage | 453 | **40** |
| p90 lines per passage | 58 | **40** |
| passages with 3+ newline runs | 85 | **0** |
| passages with trailing spaces | 78 | **0** |
| unbalanced fences | 2 | **2** |

304 passages hit the line cap. The fence-aware cap introduced no additional unbalanced fences. Artifacts: `/Users/karan/.search-ops-scratchpad/passage-noise/cli-eval`.

## Gates
- Prettier check passed
- TypeScript no-emit check passed
- Vitest passed — 24 files, 448 tests
- TypeScript build passed

`pnpm` is unavailable on this host, so the lockfile-installed binaries ran directly. The pre-commit hook failed only because it invokes missing `pnpm`; the equivalent checks above passed.



