### PR TITLE
docs(developer-index): document the `web:` id prefix

### DIFF
--- a/skills/firecrawl-developer-index/SKILL.md
+++ b/skills/firecrawl-developer-index/SKILL.md
@@ -14,7 +14,7 @@ There is **no fixed recipe**. Read the question, decide what kind it is, and cho
 - HTTP: **`GET|POST https://api.firecrawl.dev/v2/search/developer`**
   MCP: **`firecrawl_developer_search(query, k?, skills?)`**
   CLI: **`firecrawl developer <query> [--limit <n>]`**
-  Ranked results over the whole index. Each carries `id` (`issue:owner/repo#123`), `url`, and the **matched passages in markdown**, so tables and code blocks survive. The artifact kind is the `id` prefix: `doc:`, `issue:`, `pull_request:`, or `readme:`.
+  Ranked results over the whole index. Each carries `id` (`issue:owner/repo#123`), `url`, and the **matched passages in markdown**, so tables and code blocks survive. The artifact kind is the `id` prefix: `doc:`, `issue:`, `pull_request:`, or `readme:` for curated index entries, and `web:` for an open web page returned alongside them — not a curated artifact, and not something you can request or exclude by name. To keep only curated results, pass `types=["doc","issue","pull_request","readme"]`.
   The default first move for a developer question. It is the only surface that returns the passages, which is what lets you answer instead of pointing at a page.
   `k` / `--limit` is 1–100 and defaults to 10. `skills="only"` (HTTP/MCP only) restricts the search to agent-skill files.
   Keyless; send `Authorization: Bearer $FIRECRAWL_API_KEY` for higher rate limits.

--- a/skills/firecrawl-developer-index/SKILL.md
+++ b/skills/firecrawl-developer-index/SKILL.md
@@ -33,7 +33,7 @@ There is **no fixed recipe**. Read the question, decide what kind it is, and cho
 
 Only the HTTP surface takes these. On `GET`, pass `types=issue,pull_request` or repeat the parameter; on `POST`, pass arrays. All are optional.
 
-- `types` — which of `doc`, `issue`, `pull_request`, `readme` to search. Defaults to all four. Narrowing here is the cheapest way to sharpen a query.
+- `types` — which of `doc`, `issue`, `pull_request`, `readme` to search. When unset the request also returns `web:` results alongside the four curated kinds; passing an explicit list is the only way to exclude them. Narrowing here is also the cheapest way to sharpen a query.
 - `repos` (`owner/name`) scopes the repository half, meaning `issue`, `pull_request`, and `readme`; `sources` (documentation source ids, at most 20) scopes the documentation half, meaning `doc`. Passing both **unions** the halves rather than intersecting them. Both echo back in the response with `indexed: true|false` — that is how you tell "not in the index" from "found nothing".
 - A filter that cannot match any requested `type` is a `400`, not an empty list: `repos` with no repository type in `types`, or `sources` without `doc`.
 - `passages` (1–5, default 1) is the _maximum_ passages per result, not a guarantee. Raise it when one page is clearly the right page but the first passage is the wrong part of it.


### PR DESCRIPTION
## Summary

`/v2/search/developer` returns a fifth `id` prefix, `web:`, alongside the four curated kinds documented in the skill. Unscoped queries can return a majority of `web:` results, which don't come from the index. Following the skill's existing "scope last, not first" guidance and satisfying its "quote the passage, cite the url" rule then treats an open web page as a curated primary source.

This updates the enumerated prefix list in `skills/firecrawl-developer-index/SKILL.md` to mention `web:`, describe it as an open web page rather than a curated artifact, and note the workaround (pass `types=["doc","issue","pull_request","readme"]` to keep only curated results; `types=["web"]` is rejected with a 400).

Minimal single-line edit — no changes to principles, filters, or examples.

## Related

Fixes #213

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 426 passed / 7 skipped, no regressions
- [x] Skill description still under Claude Code's 1024-char frontmatter limit (205 chars)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `web:` id prefix that `/v2/search/developer` returns alongside the four curated index kinds. The skill previously listed only `doc:`, `issue:`, `pull_request:`, and `readme:`, so an agent following the "scope last" guidance could cite an open web page as if it were a curated primary source. The update marks `web:` results as open web pages and clarifies in the Filters section that unset `types` returns them too — passing `types=["doc","issue","pull_request","readme"]` is the only way to exclude them, while `types=["web"]` alone is rejected with a 400.

Fixes #213.

<sup>Written for commit c8e383dd6fa82aacbdd6aa6481e0dabf0d7e30ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/cli/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

